### PR TITLE
Fix reference to EventEmitter

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -217,8 +217,8 @@
   },
   "event_emitter": {
     "type": "github",
-    "owner": "ozjd",
-    "repo": "deno_event_emitter"
+    "owner": "denolibs",
+    "repo": "event_emitter"
   },
   "expect": {
     "type": "github",


### PR DESCRIPTION
Hi @denoland!

I just found 404 error on page: http://deno.land/x/event_emitter/
Author of repo transfer it, so I just only update reference to it.