### PR TITLE
Only try to publish to staging when email and key are present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           apiKey: ${{ secrets.cloudflareKey }}
           email: ${{ secrets.email }}
       - name: Publish Staging
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && secrets.email != '' && secrets.cloudflareKey != ''
         uses: cloudflare/wrangler-action@1.0.0
         with:
           environment: 'staging'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           apiKey: ${{ secrets.cloudflareKey }}
           email: ${{ secrets.email }}
       - name: Publish Staging
-        if: github.event_name == 'pull_request' && secerts != null
+        if: github.event_name == 'pull_request' && secrets != null
         uses: cloudflare/wrangler-action@1.0.0
         with:
           environment: 'staging'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           apiKey: ${{ secrets.cloudflareKey }}
           email: ${{ secrets.email }}
       - name: Publish Staging
-        if: github.event_name == 'pull_request' && secrets.email != '' && secrets.cloudflareKey != ''
+        if: github.event_name == 'pull_request' && secerts != null
         uses: cloudflare/wrangler-action@1.0.0
         with:
           environment: 'staging'


### PR DESCRIPTION
Currently CI fails for users that are not part of the denoland github group. This fixes that by only trying to publish to cloudflare if email and cloudflareKey are present.