### PR TITLE
Add Linux support on Homebrew

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -121,7 +121,7 @@ function Home() {
       </pre>
       <p>
         Using <a href="https://formulae.brew.sh/formula/deno">Homebrew</a>{" "}
-        (mac):
+        (mac or Linux):
       </p>
       <pre>brew install deno</pre>
       <p>


### PR DESCRIPTION
Just as [brew.sh](brew.sh) says: "The missing package manager for macOS (or Linux)"