### PR TITLE
Updated dark theme to be more easy on the eyes

### DIFF
--- a/src/Benchmarks.tsx
+++ b/src/Benchmarks.tsx
@@ -13,8 +13,9 @@ import {
   formatPercentage
 } from "./benchmark_utils";
 import { useDarkMode } from "./theme";
-import { Link } from "@material-ui/core";
+import { Link, Theme } from "@material-ui/core";
 import { Link as RouterLink } from "react-router-dom";
+import { useTheme } from "@material-ui/styles";
 
 interface Props {
   yTickFormat?: (n: number) => string;
@@ -24,7 +25,7 @@ interface Props {
 }
 
 function BenchmarkChart(props: Props) {
-  const darkMode = useDarkMode();
+  const theme = useTheme<Theme>();
 
   function viewCommitOnClick(c1: any, c2: any, { dataPointIndex }: any): void {
     window.open(
@@ -38,9 +39,14 @@ function BenchmarkChart(props: Props) {
 
   const options = {
     theme: {
-      mode: darkMode ? "dark" : "light"
+      mode: theme.palette.type,
+      palette: "palette1"
     },
     chart: {
+      background: theme.palette.background.default,
+      foreColor: theme.palette.getContrastText(
+        theme.palette.background.default
+      ),
       toolbar: {
         show: true
       },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -10,11 +10,6 @@ export const generateTheme = (darkMode: boolean) =>
       type: darkMode ? "dark" : "light",
       primary: blue,
       secondary: cyan,
-      error: {
-        main: red.A400
-      },
-      background: {
-        default: darkMode ? "#000" : "#fff"
-      }
+      error: red
     }
   });


### PR DESCRIPTION
The background is now not black anymore, but rather uses the default dark mode color from material-ui. The colors for the graphs now also match the rest of the UI.

![image](https://user-images.githubusercontent.com/7829205/67606668-668f7e80-f782-11e9-992d-704e38ee833f.png)
