### PR TITLE
fix: added InternalLink that consumes ref from material-ui

### DIFF
--- a/src/Benchmarks.tsx
+++ b/src/Benchmarks.tsx
@@ -13,7 +13,7 @@ import {
   formatPercentage
 } from "./benchmark_utils";
 import { Link, Theme } from "@material-ui/core";
-import { HashLink as RouterLink } from "react-router-hash-link";
+import { InternalLink } from "./InternalLink";
 import { useTheme } from "@material-ui/styles";
 
 interface Props {
@@ -114,14 +114,14 @@ export default function Benchmarks() {
 
   return (
     <main>
-      <Link component={RouterLink} to="/">
+      <Link component={InternalLink} to="/">
         <img alt="deno logo" src="/images/deno_logo_4.gif" width="200" />
       </Link>
       <h1>Deno Continuous Benchmarks</h1>
 
       <p>
         These plots are updated on every commit to the{" "}
-        <Link component={RouterLink} to="https://github.com/denoland/deno">
+        <Link component={InternalLink} to="https://github.com/denoland/deno">
           master branch
         </Link>
         .
@@ -133,12 +133,12 @@ export default function Benchmarks() {
       </p>
 
       <p>
-        <Link component={RouterLink} to="#recent">
+        <Link component={InternalLink} to="#recent">
           recent data
         </Link>
       </p>
       <p>
-        <Link component={RouterLink} to="#all">
+        <Link component={InternalLink} to="#all">
           all data
         </Link>{" "}
         (takes a moment to load)
@@ -156,7 +156,7 @@ export default function Benchmarks() {
 
       <h3 id="req-per-sec">
         Req/Sec{" "}
-        <Link component={RouterLink} to="#req-per-sec">
+        <Link component={InternalLink} to="#req-per-sec">
           #
         </Link>
       </h3>
@@ -176,14 +176,14 @@ export default function Benchmarks() {
       <ul>
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/deno_tcp.ts"
           >
             deno_tcp
           </Link>{" "}
           is a fake http server that doesn't parse HTTP. It is comparable to{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/node_tcp.js"
           >
             node_tcp
@@ -193,14 +193,14 @@ export default function Benchmarks() {
 
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno_std/blob/master/http/http_bench.ts"
           >
             deno_http
           </Link>{" "}
           is a web server written in TypeScript. It is comparable to{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/node_http.js"
           >
             node_http
@@ -213,33 +213,33 @@ export default function Benchmarks() {
           fake HTTP server. It blindly reads and writes fixed HTTP packets. It
           is comparable to deno_tcp and node_tcp. This is a standalone
           executable that uses{" "}
-          <Link component={RouterLink} to="https://crates.io/crates/deno">
+          <Link component={InternalLink} to="https://crates.io/crates/deno">
             the deno rust crate
           </Link>
           . The code is in{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/core/examples/http_bench.rs"
           >
             http_bench.rs
           </Link>{" "}
           and{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/core/examples/http_bench.js"
           >
             http_bench.js
           </Link>
           . single uses{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://docs.rs/tokio/0.1.19/tokio/runtime/current_thread/index.html"
           >
             tokio::runtime::current_thread
           </Link>{" "}
           and multi uses
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://docs.rs/tokio/0.1.19/tokio/runtime/"
           >
             tokio::runtime::threadpool
@@ -249,7 +249,7 @@ export default function Benchmarks() {
 
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/hyper_hello.rs"
           >
             hyper
@@ -260,7 +260,7 @@ export default function Benchmarks() {
 
       <h3 id="proxy-req-per-sec">
         Proxy Req/Sec{" "}
-        <Link component={RouterLink} to="#proxy-eq-per-sec">
+        <Link component={InternalLink} to="#proxy-eq-per-sec">
           #
         </Link>
       </h3>
@@ -280,7 +280,7 @@ export default function Benchmarks() {
       <ul>
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/deno_tcp_proxy.ts"
           >
             deno_proxy_tcp
@@ -288,7 +288,7 @@ export default function Benchmarks() {
           is a fake tcp proxy server that doesn't parse HTTP. It is comparable
           to{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/node_tcp_proxy.js"
           >
             node_proxy_tcp
@@ -298,14 +298,14 @@ export default function Benchmarks() {
 
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/deno_http_proxy.ts"
           >
             deno_proxy
           </Link>{" "}
           is an HTTP proxy server written in TypeScript. It is comparable to{" "}
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/node_http_proxy.js"
           >
             node_proxy
@@ -315,7 +315,7 @@ export default function Benchmarks() {
 
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://github.com/denoland/deno/blob/master/tools/hyper_hello.rs"
           >
             hyper
@@ -326,7 +326,7 @@ export default function Benchmarks() {
 
       <h3 id="max-latency">
         Max Latency{" "}
-        <Link component={RouterLink} to="#max-latency">
+        <Link component={InternalLink} to="#max-latency">
           #
         </Link>
       </h3>
@@ -345,7 +345,7 @@ export default function Benchmarks() {
 
       <h3 id="exec-time">
         Execution time{" "}
-        <Link component={RouterLink} to="#exec-time">
+        <Link component={InternalLink} to="#exec-time">
           #
         </Link>
       </h3>
@@ -361,28 +361,28 @@ export default function Benchmarks() {
         Log scale. This shows how much time total it takes to run a few simple
         deno programs:{" "}
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/002_hello.ts"
         >
           tests/002_hello.ts
         </Link>
         ,{" "}
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/003_relative_import.ts"
         >
           tests/003_relative_import.ts
         </Link>
         ,{" "}
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/workers_round_robin_bench.ts"
         >
           tests/workers_round_robin_bench.ts
         </Link>
         , and{" "}
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/workers_startup_bench.ts"
         >
           tests/workers_startup_bench.ts
@@ -395,7 +395,7 @@ export default function Benchmarks() {
 
       <h3 id="throughput">
         Throughput{" "}
-        <Link component={RouterLink} to="#throughput">
+        <Link component={InternalLink} to="#throughput">
           #
         </Link>
       </h3>
@@ -410,14 +410,14 @@ export default function Benchmarks() {
       <p>
         Log scale. Time it takes to pipe a certain amount of data through Deno.
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/echo_server.ts"
         >
           echo_server.ts
         </Link>{" "}
         and{" "}
         <Link
-          component={RouterLink}
+          component={InternalLink}
           to="https://github.com/denoland/deno/blob/master/tests/cat.ts"
         >
           cat.ts
@@ -427,7 +427,7 @@ export default function Benchmarks() {
 
       <h3 id="max-memory">
         Max Memory Usage{" "}
-        <Link component={RouterLink} to="#max-memory">
+        <Link component={InternalLink} to="#max-memory">
           #
         </Link>
       </h3>
@@ -441,7 +441,7 @@ export default function Benchmarks() {
 
       <h3 id="size">
         Executable size{" "}
-        <Link component={RouterLink} to="#size">
+        <Link component={InternalLink} to="#size">
           #
         </Link>
       </h3>
@@ -455,7 +455,7 @@ export default function Benchmarks() {
 
       <h3 id="threads">
         Thread count{" "}
-        <Link component={RouterLink} to="#threads">
+        <Link component={InternalLink} to="#threads">
           #
         </Link>
       </h3>
@@ -464,7 +464,7 @@ export default function Benchmarks() {
 
       <h3 id="bundles">
         Syscall count{" "}
-        <Link component={RouterLink} to="#bundles">
+        <Link component={InternalLink} to="#bundles">
           #
         </Link>
       </h3>
@@ -476,7 +476,7 @@ export default function Benchmarks() {
 
       <h3 id="bundles">
         Bundle size{" "}
-        <Link component={RouterLink} to="#syscalls">
+        <Link component={InternalLink} to="#syscalls">
           #
         </Link>
       </h3>
@@ -491,7 +491,7 @@ export default function Benchmarks() {
       <ul>
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://deno.land/std/http/file_server.ts"
           >
             file_server
@@ -500,7 +500,7 @@ export default function Benchmarks() {
 
         <li>
           <Link
-            component={RouterLink}
+            component={InternalLink}
             to="https://deno.land/std/examples/gist.ts"
           >
             gist

--- a/src/Docs.tsx
+++ b/src/Docs.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { main } from "./doc_utils";
 import Markdown from "./Markdown";
 import { useLocation } from "react-router-dom";
-import { HashLink as RouterLink } from "react-router-hash-link";
+import { InternalLink } from "./InternalLink";
 import {
   Link,
   List,
@@ -29,7 +29,7 @@ export default function Docs(props: Props) {
           {docs.map(d => {
             return (
               <ListItem key={d.name}>
-                <Link component={RouterLink} to={`?doc#${d.name}`}>
+                <Link component={InternalLink} to={`?doc#${d.name}`}>
                   {d.name}
                 </Link>
               </ListItem>
@@ -40,7 +40,7 @@ export default function Docs(props: Props) {
       {docs.map(d => {
         const href = "?doc#" + d.name;
         const title = (
-          <Link component={RouterLink} to={href} color="inherit">
+          <Link component={InternalLink} to={href} color="inherit">
             <code>{d.name}</code>
           </Link>
         );

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,6 +1,6 @@
 import React from "react";
 import CodeBlock from "./CodeBlock";
-import { HashLink as RouterLink } from "react-router-hash-link";
+import { InternalLink } from "./InternalLink";
 import "./Home.css";
 import { Link } from "@material-ui/core";
 
@@ -150,7 +150,7 @@ function Home() {
 
       <p>
         <b>
-          <Link component={RouterLink} to="/std/manual.md">
+          <Link component={InternalLink} to="/std/manual.md">
             Manual
           </Link>
         </b>
@@ -172,19 +172,19 @@ function Home() {
       <p>Modules:</p>
       <ul>
         <li>
-          <Link component={RouterLink} to="/std/">
+          <Link component={InternalLink} to="/std/">
             Standard
           </Link>
         </li>
         <li>
-          <Link component={RouterLink} to="/x/">
+          <Link component={InternalLink} to="/x/">
             Third Party
           </Link>
         </li>
       </ul>
 
       <p>
-        <Link component={RouterLink} to="/std/style_guide.md">
+        <Link component={InternalLink} to="/std/style_guide.md">
           Style Guide
         </Link>
       </p>
@@ -204,7 +204,7 @@ function Home() {
       </p>
 
       <p>
-        <Link component={RouterLink} to="/benchmarks">
+        <Link component={InternalLink} to="/benchmarks">
           Benchmarks
         </Link>
       </p>

--- a/src/InternalLink.tsx
+++ b/src/InternalLink.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { HashLink, HashLinkProps } from "react-router-hash-link";
+
+export const InternalLink = React.forwardRef((props: HashLinkProps, ref) => (
+  <HashLink {...props} />
+));

--- a/src/PathBreadcrumbs.js
+++ b/src/PathBreadcrumbs.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Breadcrumbs, Link } from "@material-ui/core";
 import { useLocation } from "react-router-dom";
-import { HashLink as RouterLink } from "react-router-hash-link";
+import { InternalLink } from "./InternalLink";
 import assert from "assert";
 
 export default function PathBreadcrumbs() {
@@ -22,7 +22,7 @@ export default function PathBreadcrumbs() {
           if (i === 0) {
             assert(!part);
             return (
-              <Link component={RouterLink} to="/" key={i}>
+              <Link component={InternalLink} to="/" key={i}>
                 deno.land
               </Link>
             );
@@ -41,7 +41,7 @@ export default function PathBreadcrumbs() {
           }
           // console.log({ parts, url });
           return (
-            <Link component={RouterLink} to={url} key={i}>
+            <Link component={InternalLink} to={url} key={i}>
               {part}
             </Link>
           );

--- a/src/Registry.js
+++ b/src/Registry.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Button, Link, ButtonGroup } from "@material-ui/core";
 import { useLocation } from "react-router-dom";
-import { HashLink as RouterLink } from "react-router-hash-link";
+import { InternalLink } from "./InternalLink";
 import Markdown from "./Markdown";
 import CodeBlock from "./CodeBlock";
 import Docs from "./Docs";
@@ -55,7 +55,7 @@ export default function Registry() {
           <td>{d.type}</td>
           <td>{d.size}</td>
           <td>
-            <Link component={RouterLink} to={name}>
+            <Link component={InternalLink} to={name}>
               {name}
             </Link>
           </td>
@@ -82,11 +82,11 @@ export default function Registry() {
       <div>
         <ButtonGroup color="primary">
           {isDocsPage ? (
-            <Button component={RouterLink} to="?">
+            <Button component={InternalLink} to="?">
               Source Code
             </Button>
           ) : hasDocsAvailable ? (
-            <Button component={RouterLink} to="?doc">
+            <Button component={InternalLink} to="?doc">
               Documentation
             </Button>
           ) : null}


### PR DESCRIPTION
Function components in React may not be passed refs: (https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components).

HashLink (RouterLink) is a function component. `material-ui` passes a ref down to the HashLink, which is not permitted. The new `InternalLink` component consumes the ref using `React.forwardRef` so it does not get passed to the HashLink anymore. 