### PR TITLE
Cleanup home page links

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -156,7 +156,7 @@ function Home() {
       </p>
 
       <p>
-        {/* 
+        {/*
           TODO(ry) The /typedoc/ path is not part of the react app. It's a
           separate static site hosted in S3 and to proxied by the CF worker.
           This is a legacy documentation site. The goal is to handle Deno's own
@@ -177,24 +177,20 @@ function Home() {
         </li>
         <li>
           <Link component={InternalLink} to="/x/">
-            Third Party
+            Third party
           </Link>
         </li>
       </ul>
 
       <p>
-        <Link component={InternalLink} to="/std/style_guide.md">
-          Style Guide
+        <Link href="https://github.com/denoland/deno/blob/master/Releases.md">
+          Releases
         </Link>
       </p>
 
       <p>
-        <Link href="https://twitter.com/deno_land">Twitter Account</Link>
-      </p>
-
-      <p>
-        <Link href="https://github.com/denoland/deno/blob/master/Releases.md">
-          Release notes
+        <Link component={InternalLink} to="/benchmarks">
+          Benchmarks
         </Link>
       </p>
 
@@ -203,9 +199,7 @@ function Home() {
       </p>
 
       <p>
-        <Link component={InternalLink} to="/benchmarks">
-          Benchmarks
-        </Link>
+        <Link href="https://twitter.com/deno_land">Twitter</Link>
       </p>
 
       <p>

--- a/src/Home.js
+++ b/src/Home.js
@@ -164,7 +164,7 @@ function Home() {
           https://github.com/denoland/deno_website2/issues/57
         */}
         <Link target="_blank" rel="noopener noreferrer" href="/typedoc/">
-          API reference
+          API Reference
         </Link>
       </p>
 
@@ -177,7 +177,7 @@ function Home() {
         </li>
         <li>
           <Link component={InternalLink} to="/x/">
-            Third party
+            Third Party
           </Link>
         </li>
       </ul>
@@ -195,7 +195,7 @@ function Home() {
       </p>
 
       <p>
-        <Link href="https://gitter.im/denolife/Lobby">Community chat room</Link>
+        <Link href="https://gitter.im/denolife/Lobby">Community Chat Room</Link>
       </p>
 
       <p>
@@ -204,7 +204,7 @@ function Home() {
 
       <p>
         <Link href="https://github.com/denolib/awesome-deno">
-          A curated list of awesome Deno things
+          More Links
         </Link>
       </p>
     </main>


### PR DESCRIPTION
Removes the Style Guide link. That's a style guide for contributing to std... misleading and seriously out of place there.

Otherwise fixes inconsistent casing and tries to use a more logical order for the links.