### PR TITLE
Add selectable line numbers

### DIFF
--- a/src/CodeBlock.tsx
+++ b/src/CodeBlock.tsx
@@ -1,20 +1,27 @@
 import React from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
+import SyntaxHighlighter, {
+  SyntaxHighlighterProps
+} from "react-syntax-highlighter";
 import lightTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light";
 import darkTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark";
 import { useDarkMode } from "./theme";
 
-interface Props {
-  language?: string;
-  value: string;
-}
+lightTheme["hljs-selection"] = {
+  backgroundColor: "#ebebeb" // https://github.com/atom/one-light-ui/blob/master/styles/ui-variables.less#L32
+};
+darkTheme["hljs-selection"] = {
+  backgroundColor: "#3a404b" // https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables.less#L32
+};
 
-function CodeBlock(props: Props) {
+function CodeBlock(props: SyntaxHighlighterProps) {
   const darkMode = useDarkMode();
   return (
     <SyntaxHighlighter
       style={darkMode ? darkTheme : lightTheme}
       language={props.language || "js"}
+      showLineNumbers={true}
+      wrapLines={true}
+      lineProps={props.lineProps}
     >
       {props.value}
     </SyntaxHighlighter>


### PR DESCRIPTION
Registry component looks for "#LX-LY" or "#LX" in `location.hash`,
selects code from line X to line Y and then scrolls to line X's position.

Selected code has lighter or darker `background-color`
(custom `hljs-selection` class added to each theme) according to
atom-one-dark-ui[1] or atom-one-light-ui[2] style declarations. The themes'
`@base-background-color` is based on the one in react-syntax-highlighter styles[3][4].
For example in the dark theme `CodeBlock's` `background-color` is `#282c34`
so `lighten(@base-background-color, 8%) = lighten(#282c34, 8%) => #3a404b`

Added line numbers for increased readability.

Edited `CodeBlock` component to use `react-syntax-highlighter's`
`SyntaxHighlighterProps` instead of custom `Props` object.

Fixes #43.

[1] https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables.less#L32
[2] https://github.com/atom/one-light-ui/blob/master/styles/ui-variables.less#L32
[3] https://github.com/conorhastings/react-syntax-highlighter/blob/master/src/styles/hljs/atom-one-dark.js#L7
[4] https://github.com/conorhastings/react-syntax-highlighter/blob/master/src/styles/hljs/atom-one-light.js#L7