### PR TITLE
Add `noble` cryptographic libraries.

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -29,6 +29,11 @@
     "owner": "chiefbiiko",
     "repo": "blake2b"
   },
+  "bls12-381": {
+    "type: "github",
+    "owner": "paulmillr",
+    "repo": "noble-bls12-381"
+  },
   "bwt": {
     "type": "github",
     "owner": "chiefbiiko",
@@ -209,6 +214,11 @@
     "type": "github",
     "owner": "zekth",
     "repo": "deno_easypath"
+  },
+  "ed25519": {
+    "type: "github",
+    "owner": "paulmillr",
+    "repo": "noble-ed25519"
   },
   "endianess": {
     "type": "github",
@@ -403,6 +413,16 @@
     "type": "github",
     "owner": "keroxp",
     "repo": "deno-redis"
+  },
+  "ripemd160": {
+    "type: "github",
+    "owner": "paulmillr",
+    "repo": "noble-ripemd160"
+  },
+  "secp256k1": {
+    "type: "github",
+    "owner": "paulmillr",
+    "repo": "noble-secp256k1"
   },
   "semver": {
     "type": "github",

--- a/src/database.json
+++ b/src/database.json
@@ -30,7 +30,7 @@
     "repo": "blake2b"
   },
   "bls12-381": {
-    "type: "github",
+    "type": "github",
     "owner": "paulmillr",
     "repo": "noble-bls12-381"
   },
@@ -216,7 +216,7 @@
     "repo": "deno_easypath"
   },
   "ed25519": {
-    "type: "github",
+    "type": "github",
     "owner": "paulmillr",
     "repo": "noble-ed25519"
   },
@@ -415,12 +415,12 @@
     "repo": "deno-redis"
   },
   "ripemd160": {
-    "type: "github",
+    "type": "github",
     "owner": "paulmillr",
     "repo": "noble-ripemd160"
   },
   "secp256k1": {
-    "type: "github",
+    "type": "github",
     "owner": "paulmillr",
     "repo": "noble-secp256k1"
   },


### PR DESCRIPTION
Hey there!

Adding a few awesome modules. The basic idea was that indunty/elliptic and friends have like 100 dependencies each, and every dep there could get hacked and screwed. One thing that's extremely important for cryptographic primitives is trustworthiness, and modern libs don't have it.

So, i've created [`noble`](https://github.com/paulmillr/noble-ed25519) libraries - they don't use any deps, are self-contained and written in TypeScript. All of them use built-in js bigints, so this is something not yet supported by almost any competition lib. Another goal for noble was to write code that can be audited by non-cryptographers. Easy!