### PR TITLE
Add `lodash_require` wrapper module.

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -303,10 +303,10 @@
     "owner": "lodash",
     "repo": "lodash"
   },
-  "lodash-deno": {
+  "lodash_require": {
     "type": "github",
     "owner": "TokenChingy",
-    "repo": "lodash-deno"
+    "repo": "lodash_require"
   },
   "math": {
     "type": "github",

--- a/src/database.json
+++ b/src/database.json
@@ -303,6 +303,11 @@
     "owner": "lodash",
     "repo": "lodash"
   },
+  "lodash-deno": {
+    "type": "github",
+    "owner": "TokenChingy",
+    "repo": "lodash-deno"
+  },
   "math": {
     "type": "github",
     "owner": "axetroy",


### PR DESCRIPTION
So after tonnes of frustration, I managed to get lodash working on the Deno runtime, I thought I'd make it into a small wrapper module since the lodash module linked here doesn't provide documentation or support.

See [#4316](https://github.com/lodash/lodash/pull/4316) and [#4240](https://github.com/lodash/lodash/issues/4240) on the `lodash/lodash` repository.