### PR TITLE
Repair the Unexpected entry and provide error fallback.

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -527,9 +527,9 @@
   },
   "unexpected": {
     "type": "esm",
-    "owner": "alexjeffburke",
-    "url": "https://unpkg.com/unexpected@${v}/",
-    "repo": "https://unexpected.js.org/"
+    "owner": "unexpectedjs",
+    "repo": "unexpected",
+    "url": "https://unpkg.com/unexpected@${v}/"
   },
   "username": {
     "type": "github",

--- a/src/registry_utils.js
+++ b/src/registry_utils.js
@@ -70,6 +70,7 @@ export function getEntry(name, branch = "master") {
     const version = branch === "master" ? "latest" : branch;
     return {
       name,
+      branch,
       raw: rawEntry,
       type: "esm",
       url: rawEntry.url.replace(/\$\{v}/, version),


### PR DESCRIPTION
The Unexpected entry was not being rendered because the type of the
entry is "esm" not "github" and we provide no valid repo. Fix the
repo/owner properties in the database but, since there are no useful
files in the repo wire up displaying README.md in our index page.

While here I also discovered that any missing type would actually
cause an exception because it fell off the end of renderDir(). This
case was actually covered in the older registry repo, so port that.