### PR TITLE
Add deno gui, a web interface for Deno

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -160,15 +160,15 @@
     "owner": "denoland",
     "repo": "deno"
   },
-  "deno_init": {
-    "type": "github",
-    "owner": "maxuuell",
-    "repo": "deno_init"
-  },
   "deno_gui": {
     "type": "github",
     "owner": "fakoua",
     "repo": "deno_gui"
+  },
+  "deno_init": {
+    "type": "github",
+    "owner": "maxuuell",
+    "repo": "deno_init"
   },
   "denofun": {
     "type": "github",

--- a/src/database.json
+++ b/src/database.json
@@ -175,6 +175,11 @@
     "owner": "syumai",
     "repo": "denoget"
   },
+  "deno_gui": {
+    "type": "github",
+    "owner": "fakoua",
+    "repo": "deno_gui"
+  },
   "denoversion": {
     "type": "github",
     "owner": "lucascaro",

--- a/src/database.json
+++ b/src/database.json
@@ -165,6 +165,11 @@
     "owner": "maxuuell",
     "repo": "deno_init"
   },
+  "deno_gui": {
+    "type": "github",
+    "owner": "fakoua",
+    "repo": "deno_gui"
+  },
   "denofun": {
     "type": "github",
     "owner": "galkowskit",
@@ -174,11 +179,6 @@
     "type": "github",
     "owner": "syumai",
     "repo": "denoget"
-  },
-  "deno_gui": {
-    "type": "github",
-    "owner": "fakoua",
-    "repo": "deno_gui"
   },
   "denoversion": {
     "type": "github",


### PR DESCRIPTION
Deno Web GUI
deno -A https://raw.githubusercontent.com/fakoua/deno_gui/master/gui.ts

- Dashboard information about deno and versions and system.
- Remote cache clean
- TypeScript cache clean
- Terminal (eval)