### PR TITLE
Add 'dargs' Argument parser for Deno

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -124,6 +124,11 @@
     "owner": "chiefbiiko",
     "repo": "curve25519"
   },
+  "dargs": {
+    "type": "github",
+    "owner": "fakoua",
+    "repo": "dargs"
+  },
   "databatcher": {
     "type": "github",
     "owner": "allain",


### PR DESCRIPTION
## dargs: argument parser for deno

### Example:

```bash
$ deno myfile.ts -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
{ _: [ 'foo', 'bar', 'baz' ],
  x: 3,
  y: 4,
  n: 5,
  a: true,
  b: true,
  c: true,
  beep: 'boop' }
```