### PR TITLE
Add Ink module: terminal string color for Deno

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -296,6 +296,11 @@
     "owner": "chiefbiiko",
     "repo": "hmac"
   },
+  "ink": {
+    "type": "github",
+    "owner": "fakoua",
+    "repo": "ink"
+  },
   "install": {
     "type": "github",
     "owner": "denoland",


### PR DESCRIPTION
Ink is a terminal string color for Deno with html like tags:

```ts
let text = ink.colorize('<red>Hello World</red>')
console.log(text)
```
OR

```ts
ink.terminal.log('<red>Hello</red> %s', '<b>World</b>')
```