### PR TITLE
feat: Add /api/versions endpoint to worker that returns recent Deno versions 

### DIFF
--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -24,6 +24,15 @@ for await (const req of s) {
 `;
 
 function Home() {
+  const [latestVersion, setLatestVersion] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch("/api/versions")
+      .then(resp => resp.json())
+      .then(versions => setLatestVersion(versions[0]))
+      .catch(err => console.error("Failed to get latest version: " + err));
+  }, []);
+
   return (
     <main>
       <header>
@@ -87,6 +96,20 @@ function Home() {
         See{" "}
         <Link to="https://github.com/denoland/deno_install">deno_install</Link>{" "}
         for more installation options.
+      </p>
+      <p>
+        Release notes for latest stable version
+        {latestVersion !== null ? `, ${latestVersion.tag},` : null} can be found{" "}
+        <Link
+          to={
+            latestVersion !== null
+              ? latestVersion.url
+              : "https://github.com/denoland/deno/releases"
+          }
+        >
+          here
+        </Link>
+        .
       </p>
 
       <h2 id="example">Example</h2>

--- a/worker/api.js
+++ b/worker/api.js
@@ -1,0 +1,40 @@
+export async function handleAPIRequest(request) {
+  const url = new URL(request.url);
+  const accept = request.headers.get("accept");
+  const isJSON = accept && accept.indexOf("application/json") >= 0;
+
+  if (!isJSON) {
+    return new Response(
+      "The client does not accept 'application/json' content",
+      {
+        status: 400,
+        statusText: "Bad Request"
+      }
+    );
+  }
+
+  if (url.pathname == "/api/versions") {
+    const resp = await fetch("https://github.com/denoland/deno/releases.atom");
+    const atom = await resp.text();
+    const matches = [...atom.matchAll(/<title>v(.*)<\/title>/g)];
+    if (!matches) {
+      return new Response("Failed to fetch releases from GitHub", {
+        status: 500,
+        statusText: "Internal Server Error"
+      });
+    }
+    const versions = matches.map(match => ({
+      tag: "v" + match[1],
+      url: "https://github.com/denoland/deno/releases/tag/v" + match[1]
+    }));
+    return new Response(JSON.stringify(versions), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  }
+
+  return new Response("API method not found: " + url.pathname, {
+    status: 404,
+    statusText: "Not Found"
+  });
+}

--- a/worker/api.js
+++ b/worker/api.js
@@ -2,27 +2,63 @@ export async function handleAPIRequest(request) {
   const url = new URL(request.url);
 
   if (url.pathname == "/api/versions") {
-    const resp = await fetch("https://github.com/denoland/deno/releases.atom");
-    const atom = await resp.text();
-    const matches = [...atom.matchAll(/<title>v(.*)<\/title>/g)];
-    if (!matches) {
-      return new Response("Failed to fetch releases from GitHub", {
-        status: 500,
-        statusText: "Internal Server Error"
-      });
-    }
-    const versions = matches.map(match => ({
-      tag: "v" + match[1],
-      url: "https://github.com/denoland/deno/releases/tag/v" + match[1]
-    }));
-    return new Response(JSON.stringify(versions), {
-      status: 200,
-      headers: { "content-type": "application/json" }
-    });
+    return handleVersionRequest(request);
   }
 
   return new Response("API method not found: " + url.pathname, {
     status: 404,
     statusText: "Not Found"
+  });
+}
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type"
+};
+
+async function handleVersionRequest(request) {
+  const { method } = request;
+  if (method === "OPTIONS") {
+    return new Response("200 OK", {
+      status: 200,
+      statusText: "OK",
+      headers: corsHeaders
+    });
+  }
+  // HEAD requests are handled by Cloudflare Workers
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("405 Method Not Allowed", {
+      status: 405,
+      statusText: "Method Not Allowed",
+      headers: corsHeaders
+    });
+  }
+
+  let matches = [];
+  try {
+    // Get versions from Github and cache them for 120 seconds if the request was a success.
+    const resp = await fetch("https://github.com/denoland/deno/releases.atom", {
+      cf: { cacheTtlByStatus: { "200-299": 120, "400-599": 1 } }
+    });
+    if (!resp.ok) throw new Error("Bad response from Github.");
+    const atom = await resp.text();
+    matches = [...atom.matchAll(/<title>v(.*)<\/title>/g)];
+    if (!matches) throw new Error("No matches were found.");
+  } catch (e) {
+    return new Response("Failed to fetch releases from GitHub", {
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: corsHeaders
+    });
+  }
+  const versions = matches.map(match => ({
+    tag: "v" + match[1],
+    url: "https://github.com/denoland/deno/releases/tag/v" + match[1]
+  }));
+  return new Response(JSON.stringify(versions), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json", ...corsHeaders }
   });
 }

--- a/worker/api.js
+++ b/worker/api.js
@@ -1,17 +1,5 @@
 export async function handleAPIRequest(request) {
   const url = new URL(request.url);
-  const accept = request.headers.get("accept");
-  const isJSON = accept && accept.indexOf("application/json") >= 0;
-
-  if (!isJSON) {
-    return new Response(
-      "The client does not accept 'application/json' content",
-      {
-        status: 400,
-        statusText: "Bad Request"
-      }
-    );
-  }
 
   if (url.pathname == "/api/versions") {
     const resp = await fetch("https://github.com/denoland/deno/releases.atom");

--- a/worker/api.js
+++ b/worker/api.js
@@ -1,7 +1,7 @@
 export async function handleAPIRequest(request) {
   const url = new URL(request.url);
 
-  if (url.pathname == "/api/versions") {
+  if (url.pathname === "/api/versions") {
     return handleVersionRequest(request);
   }
 
@@ -14,7 +14,7 @@ export async function handleAPIRequest(request) {
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type"
+  "Access-Control-Allow-Headers": ""
 };
 
 async function handleVersionRequest(request) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,3 +1,5 @@
+import { handleAPIRequest } from "./api";
+// @ts-ignore
 import { proxy } from "../src/util/registry_utils";
 
 // const REMOTE_URL = "https://deno.land";
@@ -18,6 +20,10 @@ async function handleRequest(request) {
   // console.log('request.url', url.pathname);
   const maybeProxyElsewhere =
     url.pathname.startsWith("/std") || url.pathname.startsWith("/x");
+
+  if (url.pathname.startsWith("/api")) {
+    return handleAPIRequest(request);
+  }
 
   // TODO(ry) Support docs without hitting S3...
   if (url.pathname.startsWith("/typedoc")) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,5 +1,4 @@
 import { handleAPIRequest } from "./api";
-// @ts-ignore
 import { proxy } from "../src/util/registry_utils";
 
 // const REMOTE_URL = "https://deno.land";

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 # Cloudflare Worker configuration
-account_id = "895762025d37fc687ecd72d7cc80204a"
-zone_id = "c192cf8ac042c681023493c52edd44c8"
+account_id = "93bfcf72dfea0e9f2bf5563bc71052cf"
+zone_id = "0ce0e4d3281b88d402b5e7b874f99d2f"
 
 # shared
 type = "webpack"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 # Cloudflare Worker configuration
-account_id = "93bfcf72dfea0e9f2bf5563bc71052cf"
-zone_id = "0ce0e4d3281b88d402b5e7b874f99d2f"
+account_id = "895762025d37fc687ecd72d7cc80204a"
+zone_id = "c192cf8ac042c681023493c52edd44c8"
 
 # shared
 type = "webpack"


### PR DESCRIPTION
This is an idea for how we could do #138.

You have to have 'Accept: application/json' in your headers. Returns the 10 most recent versions like this:

```json
[{"tag":"v0.29.0","url":"https://github.com/denoland/deno/releases/tag/v0.29.0"},{"tag":"v0.28.1","url":"https://github.com/denoland/deno/releases/tag/v0.28.1"},{"tag":"v0.28.0","url":"https://github.com/denoland/deno/releases/tag/v0.28.0"},{"tag":"v0.27.0","url":"https://github.com/denoland/deno/releases/tag/v0.27.0"},{"tag":"v0.26.0","url":"https://github.com/denoland/deno/releases/tag/v0.26.0"},{"tag":"v0.25.0","url":"https://github.com/denoland/deno/releases/tag/v0.25.0"},{"tag":"v0.24.0","url":"https://github.com/denoland/deno/releases/tag/v0.24.0"},{"tag":"v0.23.0","url":"https://github.com/denoland/deno/releases/tag/v0.23.0"},{"tag":"v0.22.0","url":"https://github.com/denoland/deno/releases/tag/v0.22.0"},{"tag":"v0.21.0","url":"https://github.com/denoland/deno/releases/tag/v0.21.0"}]
```

I don't know if there is rate limiting on the GitHub release feed - I don't think so.

---
fixes #138