### PR TITLE
add cross_env module

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -143,6 +143,12 @@
     "repo": "cowsay",
     "desc": "Configurable talking cow for Deno"
   },
+  "cross_env": {
+    "type": "github",
+    "owner": "axetroy",
+    "repo": "deno_cross_env",
+    "desc": "A tool for setting environment variables across platforms"
+  },
   "cursornext": {
     "type": "github",
     "owner": "clitetailor",


### PR DESCRIPTION
A cli tool for setting environment variables across platforms

```shell
deno install cross-env https://deno.land/x/cross_env/mod.ts --allow-run --allow-env

cross-env PORT=8080 HOST=0.0.0.0 deno https://example.com/server.ts
```