### PR TITLE
Prevent layout jumping on home page and reduced bundle size

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -14,6 +14,17 @@ header {
   align-items: center;
 }
 
+#deno_title {
+  margin: 0 0 10px 0;
+}
+
+#logo {
+  width: 40%;
+  min-width: 100px;
+  max-width: 200px;
+  height: 200px;
+}
+
 .hidden {
   display: none;
 }

--- a/src/component/CodeBlock.tsx
+++ b/src/component/CodeBlock.tsx
@@ -1,9 +1,15 @@
 import React from "react";
-import SyntaxHighlighter, {
+import {
+  Light as SyntaxHighlighter,
   SyntaxHighlighterProps
 } from "react-syntax-highlighter";
 import lightTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light";
 import darkTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark";
+import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
+import typescript from "react-syntax-highlighter/dist/esm/languages/hljs/typescript";
+import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
+import markdown from "react-syntax-highlighter/dist/esm/languages/hljs/markdown";
+import shell from "react-syntax-highlighter/dist/esm/languages/hljs/shell";
 import { useDarkMode } from "../hook/theme";
 
 lightTheme["hljs-selection"] = {
@@ -12,6 +18,12 @@ lightTheme["hljs-selection"] = {
 darkTheme["hljs-selection"] = {
   backgroundColor: "#3a404b" // https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables.less#L32
 };
+
+SyntaxHighlighter.registerLanguage("javascript", javascript);
+SyntaxHighlighter.registerLanguage("typescript", typescript);
+SyntaxHighlighter.registerLanguage("json", json);
+SyntaxHighlighter.registerLanguage("markdown", markdown);
+SyntaxHighlighter.registerLanguage("shell", shell);
 
 function CodeBlock(props: SyntaxHighlighterProps) {
   const darkMode = useDarkMode();

--- a/src/component/CodeBlock.tsx
+++ b/src/component/CodeBlock.tsx
@@ -5,11 +5,11 @@ import {
 } from "react-syntax-highlighter";
 import lightTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-light";
 import darkTheme from "react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark";
-import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
-import typescript from "react-syntax-highlighter/dist/esm/languages/hljs/typescript";
-import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
-import markdown from "react-syntax-highlighter/dist/esm/languages/hljs/markdown";
-import shell from "react-syntax-highlighter/dist/esm/languages/hljs/shell";
+import javascript from "react-syntax-highlighter/dist/cjs/languages/hljs/javascript";
+import typescript from "react-syntax-highlighter/dist/cjs/languages/hljs/typescript";
+import json from "react-syntax-highlighter/dist/cjs/languages/hljs/json";
+import markdown from "react-syntax-highlighter/dist/cjs/languages/hljs/markdown";
+import shell from "react-syntax-highlighter/dist/cjs/languages/hljs/shell";
 import { useDarkMode } from "../hook/theme";
 
 lightTheme["hljs-selection"] = {

--- a/src/page/Home.css
+++ b/src/page/Home.css
@@ -4,3 +4,7 @@
   text-align: center;
   padding: 4px;
 }
+
+#badges img {
+  height: 20px;
+}

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -50,13 +50,13 @@ function Home() {
 
       <p>Using Shell:</p>
       <CodeBlock
-        language={"shell"}
-        value={"curl -fsSL https://deno.land/x/install/install.sh | sh"}
+        language="shell"
+        value="curl -fsSL https://deno.land/x/install/install.sh | sh"
       />
       <p>Or using PowerShell:</p>
       <CodeBlock
-        language={"shell"}
-        value={"iwr https://deno.land/x/install/install.ps1 -useb | iex"}
+        language="shell"
+        value="iwr https://deno.land/x/install/install.ps1 -useb | iex"
       />
       <p>
         Using <Link to="https://formulae.brew.sh/formula/deno">Homebrew</Link>{" "}
@@ -78,13 +78,13 @@ function Home() {
 
       <p>Try running a simple program:</p>
       <CodeBlock
-        language={"shell"}
-        value={"deno https://deno.land/std/examples/welcome.ts"}
+        language="shell"
+        value="deno https://deno.land/std/examples/welcome.ts"
       />
 
       <p>Or a more complex one:</p>
 
-      <CodeBlock language={"typescript"} value={code} />
+      <CodeBlock language="ts" value={code} />
 
       <h2 id="dig-in">Dig in...</h2>
 

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -1,18 +1,7 @@
 import React from "react";
 import Link from "../component/Link";
+import CodeBlock from "../component/CodeBlock";
 import "./Home.css";
-
-const { Suspense } = React;
-
-const CodeBlockLazy = React.lazy(() => import("../component/CodeBlock"));
-
-function CodeBlock(props) {
-  return (
-    <Suspense fallback={""}>
-      <CodeBlockLazy {...props}></CodeBlockLazy>
-    </Suspense>
-  );
-}
 
 const code = `import { serve } from "https://deno.land/std@v0.24.0/http/server.ts";
 const body = new TextEncoder().encode("Hello World\\n");
@@ -27,14 +16,10 @@ function Home() {
   return (
     <main>
       <header>
-        <img
-          id="logo"
-          src="images/deno_logo_3.svg"
-          alt="deno logo"
-          width="200"
-        />
+        <img id="logo" src="images/deno_logo_3.svg" alt="deno logo" />
         <div>
-          <h1>Deno</h1>A secure runtime for JavaScript and TypeScript
+          <h1 id="deno_title">Deno</h1> A secure runtime for JavaScript and
+          TypeScript
         </div>
       </header>
 

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -3,9 +3,9 @@ import { Box } from "@material-ui/core";
 import { useLocation } from "react-router-dom";
 import Link from "../component/Link.tsx";
 import Spinner from "../component/Spinner";
+import CodeBlock from "../component/CodeBlock";
 import { proxy } from "../util/registry_utils";
 
-const CodeBlock = React.lazy(() => import("../component/CodeBlock"));
 const Markdown = React.lazy(() => import("../component/Markdown"));
 const Docs = React.lazy(() => import("../component/Docs"));
 

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -3,11 +3,11 @@ import { Box } from "@material-ui/core";
 import { useLocation } from "react-router-dom";
 import Link from "../component/Link.tsx";
 import Spinner from "../component/Spinner";
-import CodeBlock from "../component/CodeBlock";
 import { proxy } from "../util/registry_utils";
 
 const Markdown = React.lazy(() => import("../component/Markdown"));
 const Docs = React.lazy(() => import("../component/Docs"));
+const CodeBlock = React.lazy(() => import("../component/CodeBlock"));
 
 export default function Registry() {
   const [isLoading, setIsLoading] = React.useState(true);

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -5,9 +5,9 @@ import Link from "../component/Link.tsx";
 import Spinner from "../component/Spinner";
 import { proxy } from "../util/registry_utils";
 
+const CodeBlock = React.lazy(() => import("../component/CodeBlock"));
 const Markdown = React.lazy(() => import("../component/Markdown"));
 const Docs = React.lazy(() => import("../component/Docs"));
-const CodeBlock = React.lazy(() => import("../component/CodeBlock"));
 
 export default function Registry() {
   const [isLoading, setIsLoading] = React.useState(true);


### PR DESCRIPTION
I removed all of the unused languages for the syntax highlighter. This reduced the CodeBlock bundle from ~500MB to about ~200MB.

On the home page the layout jumped up to six times before (4x for when the badges load, 1x for the logo and 1x for the codeblocks).

I fixed this by giving the badges and logo explicit heights. I also statically added the CodeBlock bundle to the main page to stop that from jumping because of React suspense. The initial page load time is about the same and the total bundle size is actually smaller due to the reduced size of the CodeBlock bundle.

While working on the logo sizing I made the styling more responsive which makes the site look a lot less squashed on mobile in my opinion. 