### PR TITLE
add dinocord discord api lib

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -240,6 +240,12 @@
     "repo": "denoversion",
     "desc": "Deno cli to manage and bump release versions."
   },
+  "dinocord": {
+    "type": "github",
+    "owner": "sunsetkookaburra",
+    "repo": "dinocord",
+    "desc": "A Discord API Library for Deno."
+  },
   "dirname": {
     "type": "github",
     "owner": "rsp",


### PR DESCRIPTION
still in progress but want to add it. repo at [https://github.com/sunsetkookaburra/dinocord](https://github.com/sunsetkookaburra/dinocord).
dinocord is a discord api interface allowing the creation of a bot to listen to commands and other server events.