### PR TITLE
Sort benchmark popover data

### DIFF
--- a/src/page/Benchmarks.tsx
+++ b/src/page/Benchmarks.tsx
@@ -87,7 +87,7 @@ function BenchmarkChart(props: Props) {
     }
   };
 
-  const series = props.columns;
+  const series = props.columns.sort((a, b) => (a.name > b.name ? 1 : -1));
   return (
     <ApexChart type="line" options={options} series={series} height={300} />
   );

--- a/src/page/Benchmarks.tsx
+++ b/src/page/Benchmarks.tsx
@@ -87,7 +87,12 @@ function BenchmarkChart(props: Props) {
     }
   };
 
-  const series = props.columns.sort((a, b) => (a.name > b.name ? 1 : -1));
+  const series = props.columns.sort((a, b) => {
+    // Sort by last benchmark.
+    let a_last = a.data[a.data.length - 1];
+    let b_last = b.data[b.data.length - 1];
+    return b_last - a_last;
+  });
   return (
     <ApexChart type="line" options={options} series={series} height={300} />
   );


### PR DESCRIPTION
Added a `.sort` to alphabetize the data in the popovers
<img width="978" alt="Screen Shot 2020-01-20 at 9 19 55 PM" src="https://user-images.githubusercontent.com/5953350/72772948-239b4680-3bcb-11ea-80eb-b8836f74fa0f.png">
