### PR TITLE
WIP: Redirect with explicit git references in the registry

### DIFF
--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -21,35 +21,36 @@ export default function Registry() {
   const { pathname, search, hash } = useLocation();
   const firstSelectedLine = React.useRef(null);
   React.useEffect(() => {
-    setIsLoading(true);
-    const { entry, path } = proxy(pathname);
-    console.log({ path });
-    if (!path || path.endsWith("/")) {
-      // Render dir.
-      const repoUrl = `${entry.repo}${path}`;
-      renderDir(path, entry).then(dir => {
-        console.log({ dir });
-        setState({ dir, repoUrl });
-        setIsLoading(false);
-      });
-    } else {
-      // Render file.
-      const rawUrl = `${entry.url}${path}`;
-      const repoUrl = `${entry.repo}${path}`;
-      console.log("fetch", rawUrl);
-      fetch(rawUrl).then(async response => {
-        const m = await response.text();
-        setState({
-          contents: m,
-          rawUrl,
-          repoUrl
+    (async () => {
+      setIsLoading(true);
+      const { entry, path } = await proxy(pathname);
+      if (!path || path.endsWith("/")) {
+        // Render dir.
+        const repoUrl = `${entry.repo}${path}`;
+        renderDir(path, entry).then(dir => {
+          console.log({ dir });
+          setState({ dir, repoUrl });
+          setIsLoading(false);
         });
-        setIsLoading(false);
-        if (firstSelectedLine.current) {
-          window.scrollTo(0, firstSelectedLine.current.offsetTop);
-        }
-      });
-    }
+      } else {
+        // Render file.
+        const rawUrl = `${entry.url}${path}`;
+        const repoUrl = `${entry.repo}${path}`;
+        console.log("fetch", rawUrl);
+        fetch(rawUrl).then(async response => {
+          const m = await response.text();
+          setState({
+            contents: m,
+            rawUrl,
+            repoUrl
+          });
+          setIsLoading(false);
+          if (firstSelectedLine.current) {
+            window.scrollTo(0, firstSelectedLine.current.offsetTop);
+          }
+        });
+      }
+    })();
   }, [pathname]);
 
   const lineSelectionRangeMatch = hash.match(/^#L(\d+)(?:-L(\d+))?$/) || [];

--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import DATABASE from "../database.json";
 
-export function proxy(pathname) {
+export async function proxy(pathname) {
   if (pathname.startsWith("/std")) {
     return proxy("/x" + pathname);
   }
@@ -12,7 +12,7 @@ export function proxy(pathname) {
   const [nameBranch, ...rest] = nameBranchRest.split("/");
   const [name, branch] = nameBranch.split("@", 2);
   const path = rest.join("/");
-  const entry = getEntry(name, branch);
+  const entry = await getEntry(name, branch);
   if (!entry || !entry.url) {
     return null;
   }
@@ -27,12 +27,13 @@ export function proxy(pathname) {
  * @param  {string}                branch
  * @return {import('./types').Entry}
  */
-export function getEntry(name, branch = "master") {
+export async function getEntry(name, branch = null) {
   // denoland/deno_std was merged into denoland/deno. For a while we will try
   // to maintain old links for backwards compatibility with denoland/deno_std
   // but eventually tags before v0.20.0 will break.
   if (
     name === "std" &&
+    branch != null &&
     (branch === "v0.7.0" ||
       branch === "v0.8.0" ||
       branch === "v0.9.0" ||
@@ -58,16 +59,17 @@ export function getEntry(name, branch = "master") {
   if (!rawEntry) {
     return null;
   } else if (rawEntry.type === "url") {
+    const version = branch == null ? "master" : branch;
     return {
       name,
       branch,
       raw: rawEntry,
       type: "url",
-      url: rawEntry.url.replace(/\$\{b}/, branch),
-      repo: rawEntry.repo.replace(/\$\{b}/, branch)
+      url: rawEntry.url.replace(/\$\{b}/, version),
+      repo: rawEntry.repo.replace(/\$\{b}/, version)
     };
   } else if (rawEntry.type === "esm") {
-    const version = branch === "master" ? "latest" : branch;
+    const version = branch === null ? "latest" : branch;
     return {
       name,
       branch,
@@ -77,12 +79,18 @@ export function getEntry(name, branch = "master") {
       repo: rawEntry.repo.replace(/\$\{v}/, version)
     };
   } else if (rawEntry.type === "github") {
+    const branch_ =
+      branch == null
+        ? await getGithubLatestVersion(rawEntry.owner, rawEntry.repo)
+            .catch(() => getGithubLatestCommit(rawEntry.owner, rawEntry.repo))
+            .catch(() => "master")
+        : branch;
     const path = rawEntry.path || "";
-    const url = `https://raw.githubusercontent.com/${rawEntry.owner}/${rawEntry.repo}/${branch}/${path}`;
-    const repo = `https://github.com/${rawEntry.owner}/${rawEntry.repo}/tree/${branch}/${path}`;
+    const url = `https://raw.githubusercontent.com/${rawEntry.owner}/${rawEntry.repo}/${branch_}/${path}`;
+    const repo = `https://github.com/${rawEntry.owner}/${rawEntry.repo}/tree/${branch_}/${path}`;
     return {
       name,
-      branch,
+      branch: branch_,
       raw: rawEntry,
       type: "github",
       url,
@@ -90,4 +98,34 @@ export function getEntry(name, branch = "master") {
     };
   }
   return null;
+}
+
+async function getGithubLatestVersion(owner, repo) {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/releases/latest`
+  );
+  if (response.ok) {
+    return (await response.json())["tag_name"];
+  } else {
+    throw new Error(
+      `Couldn't fetch latest version of https://github.com/${owner}/${repo}`
+    );
+  }
+}
+
+async function getGithubLatestCommit(owner, repo) {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/commits?per_page=1`
+  );
+  if (response.ok) {
+    return (await response.json())[0]["sha"].substring(0, 6);
+  } else {
+    console.log(
+      `https://api.github.com/repos/${owner}/${repo}/commits?per_page=1`,
+      response.status
+    );
+    throw new Error(
+      `Couldn't fetch latest commit of https://github.com/${owner}/${repo}`
+    );
+  }
 }

--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -120,10 +120,6 @@ async function getGithubLatestCommit(owner, repo) {
   if (response.ok) {
     return (await response.json())[0]["sha"].substring(0, 6);
   } else {
-    console.log(
-      `https://api.github.com/repos/${owner}/${repo}/commits?per_page=1`,
-      response.status
-    );
     throw new Error(
       `Couldn't fetch latest commit of https://github.com/${owner}/${repo}`
     );

--- a/src/util/registry_utils.test.ts
+++ b/src/util/registry_utils.test.ts
@@ -1,47 +1,45 @@
 import DATABASE from "../database.json";
 import { proxy, getEntry } from "./registry_utils";
 
-test("check that the registry correctly handles std module", () => {
+test("check that the registry correctly handles std module", async () => {
   expect(DATABASE["std"]).toBeTruthy();
-  const entry = getEntry("std");
+  const entry = await getEntry("std");
   expect(entry).toBeTruthy();
   expect(entry.name).toBe("std");
-  expect(entry.branch).toBe("master");
+  expect(entry.branch).toMatch(/v\d+\.\d+\.\d+/);
   expect(entry.raw).toEqual(DATABASE["std"]);
   expect(entry.type).toBe("github");
   expect(entry.url).toBe(
-    "https://raw.githubusercontent.com/denoland/deno/master/std/"
+    `https://raw.githubusercontent.com/denoland/deno/${entry.branch}/std/`
   );
-  expect(entry.repo).toBe("https://github.com/denoland/deno/tree/master/std/");
+  expect(entry.repo).toBe(
+    `https://github.com/denoland/deno/tree/${entry.branch}/std/`
+  );
 });
 
-test("check that the registry correctly handles non existing module", () => {
-  const entry = getEntry("this-module-does-not-exist");
+test("check that the registry correctly handles non existing module", async () => {
+  const entry = await getEntry("this-module-does-not-exist");
   expect(entry).toBeNull();
 });
 
-test("proxy1", () => {
-  const r = proxy("/x/install/foo/bar.js");
-  expect(r).toEqual({
-    entry: {
-      name: "install",
-      branch: "master",
-      type: "github",
-      raw: {
-        type: "github",
-        owner: "denoland",
-        repo: "deno_install",
-        desc: "One-line commands to install Deno on your system."
-      },
-      url: "https://raw.githubusercontent.com/denoland/deno_install/master/",
-      repo: "https://github.com/denoland/deno_install/tree/master/"
-    },
-    path: "foo/bar.js"
-  });
+test("proxy1", async () => {
+  const { entry, path } = await proxy("/x/install/foo/bar.js");
+  expect(entry).toBeTruthy();
+  expect(entry.name).toBe("install");
+  expect(entry.branch).toBeTruthy();
+  expect(entry.raw).toEqual(DATABASE["install"]);
+  expect(entry.type).toBe("github");
+  expect(entry.url).toBe(
+    `https://raw.githubusercontent.com/denoland/deno_install/${entry.branch}/`
+  );
+  expect(entry.repo).toBe(
+    `https://github.com/denoland/deno_install/tree/${entry.branch}/`
+  );
+  expect(path).toBe("foo/bar.js");
 });
 
-test("proxy2", () => {
-  const r = proxy("/x/install@v0.1.2/foo/bar.js");
+test("proxy2", async () => {
+  const r = await proxy("/x/install@v0.1.2/foo/bar.js");
   expect(r).toEqual({
     entry: {
       name: "install",

--- a/worker/index.js
+++ b/worker/index.js
@@ -33,7 +33,7 @@ async function handleRequest(request) {
   }
 
   console.log("serve up text", url.pathname);
-  const proxied = proxy(url.pathname);
+  const proxied = await proxy(url.pathname);
   if (!proxied) {
     return new Response("Not in database.json " + url.pathname, {
       status: 404,


### PR DESCRIPTION
Currently in the registry when a tag isn't given, it silently serves up master. This makes it explicitly redirect to the URL containing an `@<ref>` to encourage this important practice. Only for github database entries.

It first looks for the tag name attached to the [latest release](https://developer.github.com/v3/repos/releases/#get-the-latest-release). If the repo has no releases it falls back to getting the SHA for the latest commit.

`https://deno.land/std/http/server.ts` -> `https://deno.land/std@v0.31.0/http/server.ts`
`https://deno.land/x/oak/mod.ts` -> `https://deno.land/x/oak@918c1b/mod.ts`

WIP: Need to figure out rate limit stuff.