### PR TITLE
fix: actually lint the code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,10 +26,16 @@
     ],
     "@typescript-eslint/ban-ts-ignore": ["off"],
     "@typescript-eslint/no-empty-function": ["off"],
-    "@typescript-eslint/explicit-function-return-type": ["off"]
+    "@typescript-eslint/explicit-function-return-type": ["off"],
+    "@typescript-eslint/no-explicit-any": ["off"],
+    "//replaced by @typescript-eslint/no-unused-vars": 0,
+    "no-unused-vars": ["off"],
+    "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
+    "react/prop-types": ["off"]
   },
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "es6": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --write '**/*.md' '{worker,src}/**/*.{js,ts,jsx,tsx}' 'public/**/*.html'",
-    "lint": "eslint src/ worker/"
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx src/ worker/"
   },
   "devDependencies": {
     "@testing-library/react": "^9.3.0",

--- a/src/component/CodeBlock.tsx
+++ b/src/component/CodeBlock.tsx
@@ -24,7 +24,7 @@ darkTheme["hljs-selection"] = {
   backgroundColor: "#3a404b" // https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables.less#L32
 };
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(_theme => ({
   copyButton: {
     position: "absolute",
     right: "2px",
@@ -63,7 +63,7 @@ function CodeBlock(props: SyntaxHighlighterProps) {
 
   function onContainerLeave() {
     clearTimeout(timer);
-    let timerId = setTimeout(() => {
+    const timerId = setTimeout(() => {
       setShowCopy(false);
     }, 500);
     setTimer(timerId);

--- a/src/component/Docs.tsx
+++ b/src/component/Docs.tsx
@@ -50,7 +50,7 @@ export default function Docs(props: Props) {
             </Link>
           );
           const subheader = <code>{d.typestr}</code>;
-          let frag = location.hash.substr(1);
+          const frag = location.hash.substr(1);
           const raised = frag === d.name;
           let docstr = null;
           if (d.docstr) {
@@ -63,7 +63,7 @@ export default function Docs(props: Props) {
                 <b>Arguments</b>
                 <List>
                   {d.args.map(arg => {
-                    let name = <code>{`${arg.name}: ${arg.typestr}`}</code>;
+                    const name = <code>{`${arg.name}: ${arg.typestr}`}</code>;
                     return (
                       <ListItem key={arg.name}>
                         <ListItemText primary={name} secondary={arg.docstr} />

--- a/src/database.test.ts
+++ b/src/database.test.ts
@@ -1,4 +1,5 @@
 import DATABASE from "./database.json";
+/* eslint-env jest */
 
 test("a database entry of type github should have a owner and repo", () => {
   for (const key in DATABASE) {
@@ -20,7 +21,7 @@ test("a database entry should never have a path starting with /", () => {
 });
 
 test("database names with dashes are not allowed", () => {
-  for (let key in DATABASE) {
+  for (const key in DATABASE) {
     expect(key.includes("-")).toBeFalsy();
   }
 });

--- a/src/page/Benchmarks.tsx
+++ b/src/page/Benchmarks.tsx
@@ -90,9 +90,9 @@ function BenchmarkChart(props: Props) {
 
   const series = props.columns.sort((a, b) => {
     // Sort by last benchmark.
-    let a_last = a.data[a.data.length - 1];
-    let b_last = b.data[b.data.length - 1];
-    return b_last - a_last;
+    const aLast = a.data[a.data.length - 1];
+    const bLast = b.data[b.data.length - 1];
+    return bLast - aLast;
   });
   return (
     <ApexChart type="line" options={options} series={series} height={300} />

--- a/src/page/Home.test.tsx
+++ b/src/page/Home.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Home from "./Home";
+/* eslint-env jest */
 
 test("contains the word deno", () => {
   const { getByText } = render(<Home />, { wrapper: MemoryRouter });

--- a/src/util/benchmark_utils.ts
+++ b/src/util/benchmark_utils.ts
@@ -204,7 +204,7 @@ function extractProxyFields(data: BenchmarkRun[]): void {
       (row as any)[name] = newField;
       for (const k of Object.getOwnPropertyNames(d)) {
         if (k.includes("_proxy")) {
-          let d2 = d as any;
+          const d2 = d as any;
           const v = d2[k];
           delete d2[k];
           (newField as any)[k] = v;

--- a/src/util/doc.test.ts
+++ b/src/util/doc.test.ts
@@ -1,6 +1,5 @@
 import { main } from "./doc_utils";
-import { readFileSync } from "fs";
-import * as path from "path";
+/* eslint-env jest */
 
 test("basic", () => {
   const rootModule = "foo.ts";

--- a/src/util/doc_parser.ts
+++ b/src/util/doc_parser.ts
@@ -37,7 +37,7 @@ function skipAlias(symbol: ts.Symbol, checker: ts.TypeChecker) {
 }
 
 const debug = false;
-function log(...args: Array<any>): void {
+function log(...args: any[]): void {
   if (debug) {
     console.log(...args);
   }
@@ -160,7 +160,7 @@ export class Parser {
         kind: "enum",
         docstr
       });
-      for (let m of node.members) {
+      for (const m of node.members) {
         const sym = this.checker.getSymbolAtLocation(m.name);
         const memberName = sym ? sym.getName() : "<unknown>";
         const memberDocstr = this.getFlatDocstr(sym);

--- a/src/util/doc_utils.ts
+++ b/src/util/doc_utils.ts
@@ -17,26 +17,26 @@ export function main(rootModule: string, rootSource: string): DocEntry[] {
 class Host implements ts.CompilerHost {
   constructor(public rootModule: string, public rootSource: string) {}
 
-  getDefaultLibFileName(options: ts.CompilerOptions): string {
+  getDefaultLibFileName(_options: ts.CompilerOptions): string {
     return "";
   }
 
   getSourceFile(
     fileName: string,
     languageVersion: ts.ScriptTarget,
-    onError?: (message: string) => void,
-    shouldCreateNewSourceFile?: boolean
+    _onError?: (message: string) => void,
+    _shouldCreateNewSourceFile?: boolean
   ): ts.SourceFile | undefined {
     // console.log("getSourceFile", fileName);
     return ts.createSourceFile(fileName, this.rootSource, languageVersion);
   }
 
   writeFile(
-    fileName: string,
-    data: string,
-    writeByteOrderMark: boolean,
-    onError?: (message: string) => void,
-    sourceFiles?: ReadonlyArray<ts.SourceFile>
+    _fileName: string,
+    _data: string,
+    _writeByteOrderMark: boolean,
+    _onError?: (message: string) => void,
+    _sourceFiles?: readonly ts.SourceFile[]
   ): void {
     assert(false);
   }
@@ -58,12 +58,12 @@ class Host implements ts.CompilerHost {
     return "\n";
   }
 
-  fileExists(path: string): boolean {
+  fileExists(_path: string): boolean {
     // console.log("fileExists", path);
     return true;
   }
 
-  readFile(path: string, encoding?: string): string | undefined {
+  readFile(_path: string, _encoding?: string): string | undefined {
     assert(false);
     return "x";
   }

--- a/src/util/registry_utils.test.ts
+++ b/src/util/registry_utils.test.ts
@@ -1,5 +1,6 @@
 import DATABASE from "../database.json";
 import { proxy, getEntry } from "./registry_utils";
+/* eslint-env jest */
 
 test("check that the registry correctly handles std module", () => {
   expect(DATABASE["std"]).toBeTruthy();


### PR DESCRIPTION
Eslint by default only lints .js file extensions.
This PR enables linting on the codebase and fixes the errors that were uncaught.

A few ESLint rules were updated to match the existing codebase style (such as not requiring react/prop-types and allowing unescaped quotes in text nodes.

State before change:
```sh
yarn eslint --ext .js,.jsx,.ts,.tsx src/ worker/
```
```
✖ 98 problems (81 errors, 17 warnings)
  10 errors and 0 warnings potentially fixable with the `--fix` option.
```
After
```
Done in 2.59s.
```