### PR TITLE
Fixed Registry buttons to match Link component

### DIFF
--- a/src/component/Button.tsx
+++ b/src/component/Button.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Button as MaterialButton } from "@material-ui/core";
+import { ButtonProps } from "@material-ui/core/Button/Button";
+import { Link as RouterLink } from "react-router-dom";
+import { isExternal } from "./Link";
+
+interface Props extends Omit<ButtonProps, "href"> {
+  to: string;
+}
+
+/** Use this component instead of MaterialUI's Button. */
+export default function Button(props: Props) {
+  const external = isExternal(props.to);
+
+  return (
+    <MaterialButton
+      {...props}
+      component={external ? "button" : RouterLink}
+      href={props.to}
+      to={props.to}
+    />
+  );
+}

--- a/src/component/Link.tsx
+++ b/src/component/Link.tsx
@@ -22,6 +22,6 @@ export default function Link(props: Props) {
   );
 }
 
-function isExternal(url: string): boolean {
+export function isExternal(url: string): boolean {
   return url.startsWith("http://") || url.startsWith("https://");
 }

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -1,7 +1,8 @@
 import React from "react";
-import { Box, ButtonGroup, Button } from "@material-ui/core";
+import { Box, ButtonGroup } from "@material-ui/core";
 import { useLocation } from "react-router-dom";
-import Link from "../component/Link.tsx";
+import Link from "../component/Link";
+import Button from "../component/Button";
 import Spinner from "../component/Spinner";
 import Title from "../component/Title";
 import { proxy } from "../util/registry_utils";
@@ -89,7 +90,11 @@ export default function Registry() {
 
     contentComponent = (
       <div>
-        <Link to={state.repoUrl}>Repository</Link>
+        <ButtonGroup size="small" variant="text" color="primary">
+          <Button component={Link} to={state.repoUrl}>
+            Repository
+          </Button>
+        </ButtonGroup>
         <br />
         <br />
         {body && <Markdown source={body} />}
@@ -108,14 +113,24 @@ export default function Registry() {
       <div>
         <ButtonGroup size="small" variant="text" color="primary">
           {isDocsPage ? (
-            <Button href="?">Source Code</Button>
+            <Button component={Link} to="?">
+              Source Code
+            </Button>
           ) : hasDocsAvailable ? (
-            <Button href="?doc">Documentation</Button>
+            <Button component={Link} to="?doc">
+              Documentation
+            </Button>
           ) : null}
           {state.repoUrl ? (
-            <Button href={state.repoUrl}>Repository</Button>
+            <Button component={Link} to={state.repoUrl}>
+              Repository
+            </Button>
           ) : null}
-          {state.rawUrl ? <Button href={state.rawUrl}>Raw</Button> : null}
+          {state.rawUrl ? (
+            <Button component={Link} to={state.rawUrl}>
+              Raw
+            </Button>
+          ) : null}
         </ButtonGroup>
         {(() => {
           if (isMarkdown) {

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -91,9 +91,7 @@ export default function Registry() {
     contentComponent = (
       <div>
         <ButtonGroup size="small" variant="text" color="primary">
-          <Button component={Link} to={state.repoUrl}>
-            Repository
-          </Button>
+          <Button to={state.repoUrl}>Repository</Button>
         </ButtonGroup>
         <br />
         <br />
@@ -113,24 +111,14 @@ export default function Registry() {
       <div>
         <ButtonGroup size="small" variant="text" color="primary">
           {isDocsPage ? (
-            <Button component={Link} to="?">
-              Source Code
-            </Button>
+            <Button to="?">Source Code</Button>
           ) : hasDocsAvailable ? (
-            <Button component={Link} to="?doc">
-              Documentation
-            </Button>
+            <Button to="?doc">Documentation</Button>
           ) : null}
           {state.repoUrl ? (
-            <Button component={Link} to={state.repoUrl}>
-              Repository
-            </Button>
+            <Button to={state.repoUrl}>Repository</Button>
           ) : null}
-          {state.rawUrl ? (
-            <Button component={Link} to={state.rawUrl}>
-              Raw
-            </Button>
-          ) : null}
+          {state.rawUrl ? <Button to={state.rawUrl}>Raw</Button> : null}
         </ButtonGroup>
         {(() => {
           if (isMarkdown) {


### PR DESCRIPTION
Moved the button component to a custom component to prevent the unnecessary page refresh when switching between documentation and source view.

Also changed the Link for folder view in the registry to a Button to match the file view.