### PR TITLE
Remove incompatible 3rd party fp-ts library

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -367,13 +367,6 @@
     "path": "src/",
     "desc": ""
   },
-   "fp_ts": {
-    "type": "github",
-    "owner": "gcanti",
-    "repo": "fp-ts",
-    "path": "src/",
-    "desc": "Functional programming in TypeScript"
-  },
   "free_port": {
     "type": "github",
     "owner": "axetroy",


### PR DESCRIPTION
fp-ts is incompatible. The import statements follow NPM-style. They are not direct links to files.