### PR TITLE
Fixed all trailing slash errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,14 +42,26 @@ function App() {
             <Route path="/style_guide(.html)?">
               <Redirect to="/std/style_guide.md" />
             </Route>
+            <Route path="/std/" component={Registry} strict />
             <Route path="/std/:stdPath" component={Registry} />
-            <Route path="/std/" component={Registry} />
+            <Route path="/std@:stdVersion/" component={Registry} strict />
             <Route path="/std@:stdVersion/:stdPath" component={Registry} />
-            <Route path="/std@:stdVersion/" component={Registry} />
-            <Route path="/x/:mod@:modVersion/:modPath" component={Registry} />
+            <Route path="/std" component={AddTrailingSlash} strict />
+            <Route
+              path="/std@:stdVersion"
+              component={AddTrailingSlash}
+              strict
+            />
+            <Route path="/x/:mod/" component={Registry} strict />
             <Route path="/x/:mod/:modPath" component={Registry} />
-            <Route path="/x/:mod" component={Registry} />
-            <Route path="/x/:mod@:modVersion" component={Registry} />
+            <Route path="/x/:mod@:modVersion/" component={Registry} strict />
+            <Route path="/x/:mod@:modVersion/:modPath" component={Registry} />
+            <Route path="/x/:mod" component={AddTrailingSlash} strict />
+            <Route
+              path="/x/:mod@:modVersion"
+              component={AddTrailingSlash}
+              strict
+            />
             <Route
               path="/x/"
               render={() => (
@@ -57,6 +69,7 @@ function App() {
                   <RegistryIndex />
                 </Suspense>
               )}
+              exact
             />
             <Route
               exact
@@ -81,5 +94,9 @@ function App() {
     </BrowserRouter>
   );
 }
+
+const AddTrailingSlash = ({ location: { pathname } }) => (
+  <Redirect to={`${pathname}/`} />
+);
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Container } from "@material-ui/core";
-import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch } from "react-router-dom";
 import PathBreadcrumbs from "./component/PathBreadcrumbs";
 import Spinner from "./component/Spinner";
 import HashLinkHandler from "./component/HashLinkHandler";
@@ -23,75 +23,69 @@ function Registry() {
 
 function App() {
   return (
-    <BrowserRouter>
-      <HashLinkHandler>
-        <Container maxWidth="md">
-          <PathBreadcrumbs />
-          <Switch>
-            <Route
-              path="/benchmarks(.html)?"
-              render={() => (
-                <Suspense fallback={<Spinner />}>
-                  <Benchmarks />
-                </Suspense>
-              )}
-            />
-            <Route path="/manual(.html)?">
-              <Redirect to="/std/manual.md" />
-            </Route>
-            <Route path="/style_guide(.html)?">
-              <Redirect to="/std/style_guide.md" />
-            </Route>
-            <Route path="/std/" component={Registry} strict />
-            <Route path="/std/:stdPath" component={Registry} />
-            <Route path="/std@:stdVersion/" component={Registry} strict />
-            <Route path="/std@:stdVersion/:stdPath" component={Registry} />
-            <Route path="/std" component={AddTrailingSlash} strict />
-            <Route
-              path="/std@:stdVersion"
-              component={AddTrailingSlash}
-              strict
-            />
-            <Route path="/x/:mod/" component={Registry} strict />
-            <Route path="/x/:mod/:modPath" component={Registry} />
-            <Route path="/x/:mod@:modVersion/" component={Registry} strict />
-            <Route path="/x/:mod@:modVersion/:modPath" component={Registry} />
-            <Route path="/x/:mod" component={AddTrailingSlash} strict />
-            <Route
-              path="/x/:mod@:modVersion"
-              component={AddTrailingSlash}
-              strict
-            />
-            <Route
-              path="/x/"
-              render={() => (
-                <Suspense fallback={<Spinner />}>
-                  <RegistryIndex />
-                </Suspense>
-              )}
-              exact
-            />
-            <Route
-              exact
-              path="/"
-              render={() => (
-                <Suspense fallback={<Spinner />}>
-                  <Home></Home>
-                </Suspense>
-              )}
-            />
-            <Route
-              path="*"
-              render={() => (
-                <Suspense fallback={<Spinner />}>
-                  <NotFound />
-                </Suspense>
-              )}
-            />
-          </Switch>
-        </Container>
-      </HashLinkHandler>
-    </BrowserRouter>
+    <HashLinkHandler>
+      <Container maxWidth="md">
+        <PathBreadcrumbs />
+        <Switch>
+          <Route
+            path="/benchmarks(.html)?"
+            render={() => (
+              <Suspense fallback={<Spinner />}>
+                <Benchmarks />
+              </Suspense>
+            )}
+          />
+          <Route path="/manual(.html)?">
+            <Redirect to="/std/manual.md" />
+          </Route>
+          <Route path="/style_guide(.html)?">
+            <Redirect to="/std/style_guide.md" />
+          </Route>
+          <Route path="/std/" component={Registry} strict />
+          <Route path="/std/:stdPath" component={Registry} />
+          <Route path="/std@:stdVersion/" component={Registry} strict />
+          <Route path="/std@:stdVersion/:stdPath" component={Registry} />
+          <Route path="/std" component={AddTrailingSlash} strict />
+          <Route path="/std@:stdVersion" component={AddTrailingSlash} strict />
+          <Route path="/x/:mod/" component={Registry} strict />
+          <Route path="/x/:mod/:modPath" component={Registry} />
+          <Route path="/x/:mod@:modVersion/" component={Registry} strict />
+          <Route path="/x/:mod@:modVersion/:modPath" component={Registry} />
+          <Route path="/x/:mod" component={AddTrailingSlash} strict />
+          <Route
+            path="/x/:mod@:modVersion"
+            component={AddTrailingSlash}
+            strict
+          />
+          <Route
+            path="/x/"
+            render={() => (
+              <Suspense fallback={<Spinner />}>
+                <RegistryIndex />
+              </Suspense>
+            )}
+            exact
+          />
+          <Route
+            exact
+            path="/"
+            render={() => (
+              <Suspense fallback={<Spinner />}>
+                <Home></Home>
+              </Suspense>
+            )}
+          />
+          <Route
+            path="*"
+            render={() => (
+              <Suspense fallback={<Spinner />}>
+                <NotFound />
+              </Suspense>
+            )}
+          />
+        </Switch>
+      </Container>
+    </HashLinkHandler>
   );
 }
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, wait } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router-dom";
+import App from "./App";
+/* eslint-env jest */
+
+test("/x/std redirects to /x/std/", async () => {
+  const history = createMemoryHistory();
+  history.push("/x/std");
+  const { getByText } = render(
+    <Router history={history}>
+      <App />
+    </Router>
+  );
+  await wait(() => expect(history.location.pathname).toEqual("/x/std/"));
+  await wait(() => expect(getByText("Deno Standard Modules")).toBeTruthy());
+});
+
+test("/std redirects to /std/", async () => {
+  const history = createMemoryHistory();
+  history.push("/std");
+  const { getByText } = render(
+    <Router history={history}>
+      <App />
+    </Router>
+  );
+  await wait(() => expect(history.location.pathname).toEqual("/std/"));
+  await wait(() => expect(getByText("Deno Standard Modules")).toBeTruthy());
+});
+
+test("/std/bytes redirects to /std/bytes/", async () => {
+  const history = createMemoryHistory();
+  history.push("/std/bytes");
+  const { getByText } = render(
+    <Router history={history}>
+      <App />
+    </Router>
+  );
+  await wait(() => expect(history.location.pathname).toEqual("/std/bytes/"));
+  await wait(() => expect(getByText("mod.ts")).toBeTruthy());
+  expect(getByText("test.ts")).toBeTruthy();
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import CssBaseline from "@material-ui/core/CssBaseline";
 import { ThemeProvider } from "@material-ui/styles";
 import App from "./App";
 import { generateTheme, useDarkMode } from "./hook/theme";
+import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.render(<Index />, document.getElementById("root"));
 
@@ -15,7 +16,9 @@ function Index() {
     <ThemeProvider theme={theme}>
       {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
       <CssBaseline />
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ThemeProvider>
   );
 }

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, ButtonGroup } from "@material-ui/core";
-import { useLocation } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import Link from "../component/Link";
 import Button from "../component/Button";
 import Spinner from "../component/Spinner";
@@ -12,6 +12,7 @@ const Markdown = React.lazy(() => import("../component/Markdown"));
 const Docs = React.lazy(() => import("../component/Docs"));
 
 export default function Registry() {
+  const history = useHistory();
   const [isLoading, setIsLoading] = React.useState(true);
   const [state, setState] = React.useState({
     contents: null,
@@ -39,6 +40,15 @@ export default function Registry() {
       const repoUrl = `${entry.repo}${path}`;
       console.log("fetch", rawUrl);
       fetch(rawUrl).then(async response => {
+        if (response.status === 404) {
+          try {
+            await renderDir(path, entry);
+            history.replace(path + "/");
+          } catch {
+            console.log("also not a directory", path);
+          }
+        }
+
         const m = await response.text();
         setState({
           contents: m,
@@ -51,7 +61,7 @@ export default function Registry() {
         }
       });
     }
-  }, [pathname]);
+  }, [pathname, history]);
 
   const lineSelectionRangeMatch = hash.match(/^#L(\d+)(?:-L(\d+))?$/) || [];
   lineSelectionRangeMatch.shift(); // Get rid of complete match


### PR DESCRIPTION
Fix #230 and fix #123 and fix #116

Examples:
- /std -> /std/
- /x/abc -> /x/abc/
- /std/bytes -> /std/bytes/ 