### PR TITLE
Add support for colon-based line references

### DIFF
--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -72,7 +72,7 @@ export default function Registry() {
   }, [pathname, history]);
   const lineSelectionRangeMatch =
     hash.match(/^#L(\d+)(?:-L(\d+))?$/) ||
-    handleAltLineRef(pathname).match(/.*\#L(\d+)/) ||
+    handleAltLineRef(pathname).match(/.*#L(\d+)/) ||
     [];
   lineSelectionRangeMatch.shift(); // Get rid of complete match
   // Handle highlighting "#LX" (same as range [X, X])

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -5,7 +5,7 @@ import Link from "../component/Link";
 import Button from "../component/Button";
 import Spinner from "../component/Spinner";
 import Title from "../component/Title";
-import { proxy } from "../util/registry_utils";
+import { proxy, handleAltLineRef } from "../util/registry_utils";
 
 const CodeBlock = React.lazy(() => import("../component/CodeBlock"));
 const Markdown = React.lazy(() => import("../component/Markdown"));
@@ -70,8 +70,10 @@ export default function Registry() {
       });
     }
   }, [pathname, history]);
-
-  const lineSelectionRangeMatch = hash.match(/^#L(\d+)(?:-L(\d+))?$/) || [];
+  const lineSelectionRangeMatch =
+    hash.match(/^#L(\d+)(?:-L(\d+))?$/) ||
+    handleAltLineRef(pathname).match(/.*\#L(\d+)/) ||
+    [];
   lineSelectionRangeMatch.shift(); // Get rid of complete match
   // Handle highlighting "#LX" (same as range [X, X])
   if (

--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -11,7 +11,7 @@ export function proxy(pathname) {
   const nameBranchRest = pathname.replace(/^\/x\//, "");
   const [nameBranch, ...rest] = nameBranchRest.split("/");
   const [name, branch] = nameBranch.split("@", 2);
-  const path = rest.join("/");
+  const path = handleAltLineRef(rest.join("/"));
   const entry = getEntry(name, branch);
   if (!entry || !entry.url) {
     return null;
@@ -90,4 +90,17 @@ export function getEntry(name, branch = "master") {
     };
   }
   return null;
+}
+
+export function handleAltLineRef(rawPath) {
+  // handle paths that contain alternate line # references,
+  // such as example.ts:100:10.
+  const hasAltLineRef = /(.*\.[\w]*)(:.*)/.test(rawPath);
+  if (!hasAltLineRef) {
+    return rawPath;
+  }
+  const pathGroup = rawPath.match(/(.*\.[\w]*)(:.*)/)[1];
+  const lineRefGroup = rawPath.match(/(.*\.[\w]*)(:.*)/)[2];
+  const lineRef = lineRefGroup.match(/^:(\d+)/)[1];
+  return `${pathGroup}#L${lineRef}`;
 }

--- a/src/util/registry_utils.test.ts
+++ b/src/util/registry_utils.test.ts
@@ -60,3 +60,23 @@ test("proxy2", () => {
     path: "foo/bar.js"
   });
 });
+
+test("proxy3", () => {
+  const r = proxy("/x/install@v0.1.2/foo/bar.js:100:10");
+  expect(r).toEqual({
+    entry: {
+      name: "install",
+      branch: "v0.1.2",
+      type: "github",
+      raw: {
+        type: "github",
+        owner: "denoland",
+        repo: "deno_install",
+        desc: "One-line commands to install Deno on your system."
+      },
+      url: "https://raw.githubusercontent.com/denoland/deno_install/v0.1.2/",
+      repo: "https://github.com/denoland/deno_install/tree/v0.1.2/"
+    },
+    path: "foo/bar.js#L100"
+  });
+});


### PR DESCRIPTION
Addresses #210

Second swing at this issue and now have a working solution.

Currently, navigating to [https://deno.land/std/examples/echo_server.ts#L5](https://deno.land/std/examples/echo_server.ts#L5) in a browser will display pretty-printed code, with line 5 highlighted.

The Deno CLI provides line references in errors in a different format: https://deno.land/std/examples/echo_server.ts:5:8

This PR uses `proxy()` in `registry_utils.js` to re-write the "incorrect" line references to the supported style. Column references are discarded.