### PR TITLE
Add the docopt.js package

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -288,6 +288,12 @@
     "repo": "docable",
     "desc": "An open-source doc block parser for generating documenation as JSON."
   },
+  "docopt": {
+    "type": "github",
+    "owner": "eyal-shalev",
+    "repo": "docopt.js",
+    "desc": "The command line option parser, that will make you smile."
+  },
   "dotenv": {
     "type": "github",
     "owner": "pietvanzoen",


### PR DESCRIPTION
[docopt.js](https://github.com/eyal-shalev/docopt.js) is a typescript implementation of the [github.com/docopt/docopt](https://github.com/docopt/docopt) option parser.