### PR TITLE
Add protobuf

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -701,6 +701,13 @@
     "repo": "deno_process",
     "desc": "process module for Deno"
   },
+  "protobuf": {
+    "type": "github",
+    "owner": "seishun",
+    "repo": "deno-protobuf",
+    "path": "/runtime",
+    "desc": "Protocol Buffers - Google's data interchange format"
+  },
   "purify": {
     "type": "github",
     "owner": "aynik",

--- a/src/database.json
+++ b/src/database.json
@@ -705,7 +705,7 @@
     "type": "github",
     "owner": "seishun",
     "repo": "deno-protobuf",
-    "path": "/runtime",
+    "path": "runtime/",
     "desc": "Protocol Buffers - Google's data interchange format"
   },
   "purify": {


### PR DESCRIPTION
[Contributors welcome!](https://github.com/seishun/deno-protobuf)

I couldn't find any information about the js/experimental subdirectory in https://github.com/protocolbuffers/protobuf, but it looks like Google is intending for it to replace the existing runtime. It would be great if someone can get me in touch with the people working on it - I would love to find out more about the roadmap and if possible take part in the development.