### PR TITLE
Fix typedoc redirect

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -18,12 +18,10 @@ async function handleRequest(request) {
   const maybeProxyElsewhere =
     url.pathname.startsWith("/std") || url.pathname.startsWith("/x");
 
-  // TODO(ry) Support docs without hitting S3...
   if (url.pathname.startsWith("/typedoc")) {
-    return redirect(
-      url,
+    return Response.redirect(
       "https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts",
-      request
+      307
     );
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 # Cloudflare Worker configuration
-account_id = "895762025d37fc687ecd72d7cc80204a"
+account_id = "93bfcf72dfea0e9f2bf5563bc71052cf"
 zone_id = "c192cf8ac042c681023493c52edd44c8"
 
 # shared


### PR DESCRIPTION
I messed up in my PR yesterday which broke the /typedoc links. Our function `redirect` in the worker actually proxies and does not redirect which confused me. /typedoc should now correctly redirect.