### PR TITLE
Auto-focus Third Party Modules search field

### DIFF
--- a/src/page/RegistryIndex.js
+++ b/src/page/RegistryIndex.js
@@ -66,6 +66,7 @@ export default function RegistryIndex() {
         label="Search"
         type="search"
         value={query}
+        autoFocus={true}
         onChange={e => setQuery(e.target.value)}
       />
 

--- a/src/page/RegistryIndex.js
+++ b/src/page/RegistryIndex.js
@@ -66,8 +66,8 @@ export default function RegistryIndex() {
         label="Search"
         type="search"
         value={query}
-        autoFocus={true}
         onChange={e => setQuery(e.target.value)}
+        autoFocus
       />
 
       <p>{filtered.length} third party modules:</p>


### PR DESCRIPTION
Add the [`autoFocus`](https://material-ui.com/api/text-field/#props) attribute to the Third Party Modules search field for better ergonomics when navigating directly to [deno.land/x](https://deno.land/x).

Related to #176.