### PR TITLE
(Hopefully) fixed README.md casing bug

### DIFF
--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -228,7 +228,7 @@ async function renderDir(pathname, entry) {
       const rawUrl =
         entryType === "esm"
           ? `${entry.url}${path}${entry.name}`
-          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}${entry.name}`;
+          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}/${entry.name}`;
       try {
         const response = await fetch(rawUrl);
         if (response.ok) body = await response.text();

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -226,7 +226,9 @@ async function renderDir(pathname, entry) {
     // showing the contents of the README file instead if it exists.
     if (files.some(entry => entry.name.toLowerCase() === "readme.md")) {
       const rawUrl =
-        entryType === "esm" ? `${entry.url}${path}${entry.name}` : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}${entry.name}`;
+        entryType === "esm"
+          ? `${entry.url}${path}${entry.name}`
+          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}${entry.name}`;
       try {
         const response = await fetch(rawUrl);
         if (response.ok) body = await response.text();

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -224,11 +224,15 @@ async function renderDir(pathname, entry) {
 
     // no useful files exist in the repository, so opt to attempt
     // showing the contents of the README file instead if it exists.
-    if (files.some(entry => entry.name.toLowerCase() === "readme.md")) {
+    const readme = files.find(
+      entry => entry.name.toLowerCase() === "readme.md"
+    );
+
+    if (readme) {
       const rawUrl =
         entryType === "esm"
-          ? `${entry.url}${path}${entry.name}`
-          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}/${entry.name}`;
+          ? `${entry.url}${path}${readme.name}`
+          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}${readme.name}`;
       try {
         const response = await fetch(rawUrl);
         if (response.ok) body = await response.text();

--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -224,11 +224,9 @@ async function renderDir(pathname, entry) {
 
     // no useful files exist in the repository, so opt to attempt
     // showing the contents of the README file instead if it exists.
-    if (files.some(entry => entry.name === "README.md")) {
+    if (files.some(entry => entry.name.toLowerCase() === "readme.md")) {
       const rawUrl =
-        entryType === "esm"
-          ? `${entry.url}${path}README.md`
-          : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}README.md`;
+        entryType === "esm" ? `${entry.url}${path}${entry.name}` : `https://raw.githubusercontent.com/${owner}/${repo}/${entry.branch}/${path}${entry.name}`;
       try {
         const response = await fetch(rawUrl);
         if (response.ok) body = await response.text();


### PR DESCRIPTION
I don't have any experience developing in React, although I do have experience with Vue.js and a lot of JavaScript. I wrote this "fix" to allow the site to display any readme.md file without caring about the capitalization!

I'm hoping someone with the repo already running on their machine could check if it actually works though since I don't have a live environment.