### PR TITLE
Adding the 'contribute' link to the deno.land landing page

### DIFF
--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -138,6 +138,10 @@ function Home() {
       </p>
 
       <p>
+        <Link to="/std/manual.md#contributing">Contributing</Link>
+      </p>
+
+      <p>
         <Link to="https://github.com/denolib/awesome-deno">More Links</Link>
       </p>
     </main>


### PR DESCRIPTION
Just making the ramp up easier for new contributors. Having the "Contributing" link in the landing page makes it easier for developers to go directly to the sweet sweet code. 

![image](https://user-images.githubusercontent.com/1918442/80306839-c1d31580-8793-11ea-8d98-abdb96a28569.png)
