### PR TITLE
Fix `/std/bytes redirects to /std/bytes/` test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -32,12 +32,12 @@ test("/std redirects to /std/", async () => {
 test("/std/bytes redirects to /std/bytes/", async () => {
   const history = createMemoryHistory();
   history.push("/std/bytes");
-  const { getByText } = render(
+  const { getAllByText } = render(
     <Router history={history}>
       <App />
     </Router>
   );
   await wait(() => expect(history.location.pathname).toEqual("/std/bytes/"));
-  await wait(() => expect(getByText("mod.ts")).toBeTruthy());
-  expect(getByText("test.ts")).toBeTruthy();
-});
+  await wait(() => expect(getAllByText("mod.ts").length).toBeGreaterThan(0));
+  expect(getAllByText("test.ts").length).toBeGreaterThan(0);
+}, 20000);


### PR DESCRIPTION
This test started failing because [this commit](https://github.com/denoland/deno/commit/6efdacddf30b5247b66596a44226687ff21a8f80) changed what the `/std/bytes` page looks like.