### PR TITLE
Added Skimming module to database.json

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -1060,6 +1060,12 @@
     "repo": "siphash24",
     "desc": "SipHash24 implemented in WebAssembly."
   },
+  "skimming": {
+    "type": "github",
+    "owner": "petruki",
+    "repo": "skimming",
+    "desc": "Skimming is a search engine module for Deno."
+  },
   "slash": {
     "type": "github",
     "owner": "justjavac",


### PR DESCRIPTION
Skimming is a data fetcher for Deno. The idea is to provide a simple and efficient module to fetch content.

- Fetch documents online skim() or local skimContent()
- Customizable cache
- Customizable preview
- Ignore case option
- Trim content option to display only complete information
- Regex support