### PR TITLE
doc: update pinned version of server.ts example

### DIFF
--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -4,7 +4,7 @@ import CodeBlock from "../component/CodeBlock";
 import Title from "../component/Title";
 import "./Home.css";
 
-const code = `import { serve } from "https://deno.land/std@v0.36.0/http/server.ts";
+const code = `import { serve } from "https://deno.land/std@v0.42.0/http/server.ts";
 const s = serve({ port: 8000 });
 console.log("http://localhost:8000/");
 for await (const req of s) {


### PR DESCRIPTION
The std version referenced for the server.ts "complex" example at the top of the manual is 0.36. 
 Given all the breaking changes in 0.42, this older version needs updated to the latest release so examples work for visitors who are trying out Deno for the first time with the latest release.  

Related: https://github.com/denoland/deno/issues/5019. 