### PR TITLE
update style.css to fix images spilling over page

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,7 @@
+#root img {
+  max-width: 100%;
+}
+
 #manual img {
   width: 100%;
   max-width: 800px;


### PR DESCRIPTION
Closes #371.
`#root img {` is at the top for minimum specificity, allowing it to be overridden.