### PR TITLE
registry(std): Use old branch resolution for non-version branches

### DIFF
--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -15,7 +15,7 @@ export function proxy(pathname) {
   const name = s[0];
   let branch = s[1];
   // std@0.42.0 should use git tag std/0.42.0
-  if (name == "std" && branch && branch !== "master") {
+  if (name == "std" && branch?.match(/^v?\d+\.\d+\.\d+$/)) {
     branch = branch.replace(/^v/, "");
     branch = "std/" + branch;
   }


### PR DESCRIPTION
`std@0.42.0` should use git tag `std/0.42.0`, but `std@1fddcc3` should use git ref `1fddcc3` as before.