### PR TITLE
Add youtube-deno: A Deno client for the YouTube API

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -1336,6 +1336,12 @@
     "repo": "yaml-wasm",
     "desc": "WebAssembly module to parse YAML"
   },
+  "youtube-deno": {
+  "type": "github",
+  "owner": "akshgpt7",
+  "repo": "youtube-deno",
+  "desc": "A Deno client for the YouTube Data API v3. Lets you incorporate core YouTube features and almost any interaction with YouTube in your application."
+  },
   "zstd": {
     "type": "github",
     "owner": "xpyxel",

--- a/src/database.json
+++ b/src/database.json
@@ -1336,7 +1336,7 @@
     "repo": "yaml-wasm",
     "desc": "WebAssembly module to parse YAML"
   },
-  "youtube-deno": {
+  "youtube_deno": {
     "type": "github",
     "owner": "akshgpt7",
     "repo": "youtube-deno",

--- a/src/database.json
+++ b/src/database.json
@@ -1337,10 +1337,10 @@
     "desc": "WebAssembly module to parse YAML"
   },
   "youtube-deno": {
-  "type": "github",
-  "owner": "akshgpt7",
-  "repo": "youtube-deno",
-  "desc": "A Deno client for the YouTube Data API v3. Lets you incorporate core YouTube features and almost any interaction with YouTube in your application."
+    "type": "github",
+    "owner": "akshgpt7",
+    "repo": "youtube-deno",
+    "desc": "A Deno client for the YouTube Data API v3. Lets you incorporate core YouTube features and almost any interaction with YouTube in your application."
   },
   "zstd": {
     "type": "github",


### PR DESCRIPTION
`youtube-deno` is a Deno client library for the YouTube Data API v3.

Lets you incorporate core YouTube features, such as uploading videos, creating and managing playlists, searching for content, and almost any interaction with YouTube in your application.

[Repository link](https://github.com/akshgpt7/youtube-deno).