### PR TITLE
fix(std): Extend branch pattern for std versions

### DIFF
--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -15,7 +15,7 @@ export function proxy(pathname) {
   const name = s[0];
   let branch = s[1];
   // std@0.42.0 should use git tag std/0.42.0
-  if (name == "std" && branch?.match(/^v?\d+\.\d+\.\d+(-.*)?$/)) {
+  if (name == "std" && branch && branch.match(/^v?\d+\.\d+\.\d+(-.*)?$/)) {
     branch = branch.replace(/^v/, "");
     branch = "std/" + branch;
   }

--- a/src/util/registry_utils.js
+++ b/src/util/registry_utils.js
@@ -15,7 +15,7 @@ export function proxy(pathname) {
   const name = s[0];
   let branch = s[1];
   // std@0.42.0 should use git tag std/0.42.0
-  if (name == "std" && branch?.match(/^v?\d+\.\d+\.\d+$/)) {
+  if (name == "std" && branch?.match(/^v?\d+\.\d+\.\d+(-.*)?$/)) {
     branch = branch.replace(/^v/, "");
     branch = "std/" + branch;
   }


### PR DESCRIPTION
This URL shouldn't work: https://deno.land/std@v1.0.0-rc1/path/mod.ts