### PR TITLE
Remove link to doc.deno.land if file is mardown

### DIFF
--- a/src/page/Registry.js
+++ b/src/page/Registry.js
@@ -129,7 +129,9 @@ export default function Registry() {
     contentComponent = (
       <div>
         <ButtonGroup size="small" variant="text" color="primary">
-          <Button to={docsURL}>Documentation</Button>
+          {!isMarkdown ? (
+            <Button to={docsURL}>Documentation</Button>
+          ) : null}
           {state.repoUrl ? (
             <Button to={state.repoUrl}>Repository</Button>
           ) : null}


### PR DESCRIPTION
Hide link to documentation if it's a markdown file.

Reported in the here: https://github.com/denoland/doc_website/issues/82