### PR TITLE
Fix navbar menu that stays hidden on md size

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -96,7 +96,7 @@ const Header = ({ subtitle }: { subtitle?: string }) => {
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
-        <div className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden">
+        <div className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right lg:hidden">
           <div className="rounded-lg shadow-md">
             <div className="rounded-lg bg-white shadow-xs overflow-hidden">
               <div className="px-5 pt-4 flex items-center justify-between">


### PR DESCRIPTION
## Issue:
The navbar menu doesn't show when you click on the burger icon on md screen size.
## Record:
![Peek 2020-05-13 23-33](https://user-images.githubusercontent.com/23297439/81876444-38cd2400-9572-11ea-9f34-f402ddc0acc9.gif)