### PR TITLE
fix: incorrect description on Deno hoodie page

### DIFF
--- a/pages/v1/hoodie.tsx
+++ b/pages/v1/hoodie.tsx
@@ -15,7 +15,7 @@ const V1Hoodie = () => {
         <title>Deno 1.0 Hoodie</title>
         <meta
           name="description"
-          content="Deno, a secure runtime htmlFor JavaScript and TypeScript."
+          content="A limited edition, premium quality Deno 1.0 hoodie that you can order to help support the Deno project."
         />
       </Head>
       <Header />


### PR DESCRIPTION
The old description had a funny `htmlFor` in it. Changed the whole description to a more appropriate one. 