### PR TITLE
Add is-promise npm package

### DIFF
--- a/database.json
+++ b/database.json
@@ -720,6 +720,11 @@
     "repo": "is_exe",
     "desc": "detect if a file is executable or not"
   },
+  "is-promise": {
+    "type": "npm",
+    "package": "is-promise",
+    "desc": "Test whether an object looks like a promise"
+  },
   "jbq": {
     "type": "github",
     "owner": "krnik",


### PR DESCRIPTION
It can currently be used in deno via:

```js
import isPromise from 'https://unpkg.com/is-promise@4.0.0/index.mjs';

if (isPromise({then: () => {}})) {
  console.log('it is a promise');
} else {
  console.log('it is not a promise');
}
```

I'm not sure if there's anything else I should be doing to properly support deno.