### PR TITLE
Fix header a11y

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,6 +37,7 @@ const Header = ({ subtitle }: { subtitle?: string }) => {
               fill="none"
               viewBox="0 0 24 24"
             >
+              <title>Menu</title>
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -48,28 +49,28 @@ const Header = ({ subtitle }: { subtitle?: string }) => {
         </div>
         <div className="hidden lg:flex md:ml-10 items-end">
           <Link href="/" as="/#installation">
-            <a className="font-medium text-gray-500 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">
+            <a className="font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
               Install
             </a>
           </Link>
           <Link href="/[identifier]" as="/manual">
-            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">
+            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
               The Manual
             </a>
           </Link>
           <Link href="/[identifier]" as="/std">
-            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">
+            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
               Standard Library
             </a>
           </Link>
           <Link href="/x">
-            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">
+            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
               Third Party Modules
             </a>
           </Link>
           <a
             href="https://github.com/denoland"
-            className="ml-10 text-gray-500 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out"
+            className="ml-10 text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out"
           >
             <span className="sr-only">GitHub</span>
             <svg
@@ -77,6 +78,7 @@ const Header = ({ subtitle }: { subtitle?: string }) => {
               fill="currentColor"
               viewBox="0 0 24 24"
             >
+              <title>Github</title>
               <path
                 fillRule="evenodd"
                 d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"

--- a/components/app.css
+++ b/components/app.css
@@ -7,6 +7,13 @@
 
 @import "tailwindcss/utilities";
 
+/* removes focus outlines on mouse clicks */
+*:focus:not(:focus-visible),
+*::before:focus:not(:focus-visible),
+*::after:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .link {
   @apply text-blue-500;
   @apply transition;


### PR DESCRIPTION
# Never remove CSS outlines

The solution today in menu is remove focus outline in links. But this is cause a big problem on usability.

> Style the element itself. You can remove the outline as long as you style the focused element differently (using a combination of color, background-color, border or text-decoration: underline for example). When using this approach, avoid using color alone as the only visual means of determining focus, as color blind people may not be able to distinguish the focus state from the inactive state.

https://a11yproject.com/posts/never-remove-css-outlines/
https://github.com/WICG/focus-visible/issues/128