### PR TITLE
Better manual docs title

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -102,7 +102,7 @@ function Manual() {
   useEffect(() => {
     // Is doc Markdown loaded?
     if (content && content.length > 0) {
-      let title = content.match(/# (.*?)(\r|\n)/);
+      const title = content.match(/# (.*?)(\r|\n)/);
       if (title && title.length > 0) {
         document.title = `${title[1]} | The Deno Manual`;
       }

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -99,6 +99,16 @@ function Manual() {
       });
   }, []);
 
+  useEffect(() => {
+    // Is doc Markdown loaded?
+    if (content && content.length > 0) {
+      let title = content?.match(/# (.*?)(\r|\n)/)[1];
+      if (title && title.length > 0) {
+        document.title = `${title} | The Deno Manual`;
+      }
+    }
+  }, [content]);
+
   function gotoVersion(newVersion: string) {
     push(
       `/[identifier]${path ? "/[...path]" : ""}`,

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -102,7 +102,7 @@ function Manual() {
   useEffect(() => {
     // Is doc Markdown loaded?
     if (content && content.length > 0) {
-      let title = content?.match(/# (.*?)(\r|\n)/)[1];
+      let title = content.match(/# (.*?)(\r|\n)/)[1];
       if (title && title.length > 0) {
         document.title = `${title} | The Deno Manual`;
       }

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -102,9 +102,9 @@ function Manual() {
   useEffect(() => {
     // Is doc Markdown loaded?
     if (content && content.length > 0) {
-      let title = content.match(/# (.*?)(\r|\n)/)[1];
+      let title = content.match(/# (.*?)(\r|\n)/);
       if (title && title.length > 0) {
-        document.title = `${title} | The Deno Manual`;
+        document.title = `${title[1]} | The Deno Manual`;
       }
     }
   }, [content]);


### PR DESCRIPTION
Add manual docs title to browser title for better navigation between open manual tabs. 

### Why?

When you open a few new tabs on your browser they will appear like this:  
 

![](https://user-images.githubusercontent.com/23459375/81960155-307bf400-9619-11ea-8f6e-2a22979381c8.png)

This makes harder navigate between manuals when you learning. So, I added manual docs title to browser title for better navigation.