### PR TITLE
Fix typo on Acknowledgements

### DIFF
--- a/public/v1.md
+++ b/public/v1.md
@@ -228,7 +228,7 @@ Deno is difficult.
 
 Many thanks to the
 [many contributors](https://github.com/denoland/deno/graphs/contributors) who
-helped make this release possible. Espcially:
+helped make this release possible. Especially:
 [@kitsonk](https://github.com/kitsonk) who has had a massive hand in many parts
 of the system, including (but not limited to) the TypeScript compiler host,
 deno_typescript, deno bundle, deno install, deno types, streams implementation.


### PR DESCRIPTION
I just happened to see a small typo. I'm not sure I saw a contributions guideline for the deno_website2, if I absolutely missed it apologies. Please direct me to it.