### PR TITLE
Add denom to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -423,6 +423,12 @@
     "repo": "denomander",
     "desc": "Deno command-line interfaces inspired from commander.js"
   },
+  "denom": {
+    "type": "github",
+    "owner": "Qu4k",
+    "repo": "denom",
+    "desc": "Monitor any changes in your Deno application and automagically restart 🌟"
+  },
   "denon": {
     "type": "github",
     "owner": "eliassjogreen",

--- a/database.json
+++ b/database.json
@@ -419,7 +419,7 @@
   },
   "denom": {
     "type": "github",
-    "owner": "Qu4k",
+    "owner": "denosaurs",
     "repo": "denom",
     "desc": "Monitor any changes in your Deno application and automagically restart 🌟"
   },

--- a/database.json
+++ b/database.json
@@ -417,17 +417,17 @@
     "repo": "denoget",
     "desc": "denoget installs executable deno script."
   },
-  "denomander": {
-    "type": "github",
-    "owner": "siokas",
-    "repo": "denomander",
-    "desc": "Deno command-line interfaces inspired from commander.js"
-  },
   "denom": {
     "type": "github",
     "owner": "Qu4k",
     "repo": "denom",
     "desc": "Monitor any changes in your Deno application and automagically restart 🌟"
+  },
+  "denomander": {
+    "type": "github",
+    "owner": "siokas",
+    "repo": "denomander",
+    "desc": "Deno command-line interfaces inspired from commander.js"
   },
   "denon": {
     "type": "github",


### PR DESCRIPTION
[Denom](https://github.com/Qu4k/denom) is a Deno project daemon that reimplements functionality from the fantastic nodemon node library. It can be used as a standalone CLI for
project monitoring and reloading but it can also be used as a module.