### PR TITLE
Add cargo as an installation method on the main page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -323,10 +323,7 @@ const InstallSection = () => {
   const cargo = (
     <div key="cargo" className="my-4 text-gray-700">
       <p className="py-2 font-bold">Using Cargo (Windows, macOS, Linux):</p>
-      <CodeBlock
-        language="bash"
-        code={`cargo install deno`}
-      />
+      <CodeBlock language="bash" code={`cargo install deno`} />
     </div>
   );
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -346,7 +346,6 @@ const InstallSection = () => {
       {homebrew}
       {chocolatey}
       {scoop}
-      {cargo}
       <p className="my-4 text-gray-700">
         See{" "}
         <a className="link" href="https://github.com/denoland/deno_install">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -320,6 +320,15 @@ const InstallSection = () => {
       <CodeBlock language="bash" code={`scoop install deno`} />
     </div>
   );
+  const cargo = (
+    <div key="cargo" className="my-4 text-gray-700">
+      <p className="py-2 font-bold">Using Cargo (Windows, macOS, Linux):</p>
+      <CodeBlock
+        language="bash"
+        code={`cargo install deno`}
+      />
+    </div>
+  );
 
   return (
     <>
@@ -333,9 +342,11 @@ const InstallSection = () => {
       </p>
       {shell}
       {powershell}
+      {cargo}
       {homebrew}
       {chocolatey}
       {scoop}
+      {cargo}
       <p className="my-4 text-gray-700">
         See{" "}
         <a className="link" href="https://github.com/denoland/deno_install">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -296,7 +296,7 @@ const InstallSection = () => {
   const homebrew = (
     <div key="homebrew" className="my-4 text-gray-700">
       <p className="mb-2 font-bold">Using Homebrew (macOS):</p>
-      <CodeBlock language="typescript" code={`brew install deno`} />
+      <CodeBlock language="bash" code={`brew install deno`} />
     </div>
   );
   const powershell = (


### PR DESCRIPTION
Related to #480 - I don't see any reason to not have cargo as one of the available installation methods. Especially since it's the only one that works on all major platforms (Windows, macOS, Linux) and is actually [mentioned in the manual](https://deno.land/manual/getting_started/installation).

Edit:
since I was changing this file already - homebrew codeblock was using `typescript` as its language for some reason, causing a visual inconsistency:
![image](https://user-images.githubusercontent.com/25460763/82105311-2ede2900-970a-11ea-8415-6f8585b442ad.png)
So I changed that to `bash` to be consistent with other installation blocks (especially since unlike PowerShell which is also using `bash` as a language in the codeblock macOS uses zsh, which is much closer to bash). Now it's consistent:
![image](https://user-images.githubusercontent.com/25460763/82105374-87152b00-970a-11ea-9e67-2bfaabfa1fb0.png)
