### PR TITLE
Highlight active TOC heading

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -179,7 +179,7 @@ function Manual() {
                     />
                   </div>
                   {tableOfContents && (
-                    <ToC tableOfContents={tableOfContents} version={version} />
+                    <ToC tableOfContents={tableOfContents} version={version} path={path} />
                   )}
                 </div>
               </Transition>
@@ -210,7 +210,7 @@ function Manual() {
               />
             </div>
             {tableOfContents && (
-              <ToC tableOfContents={tableOfContents} version={version} />
+              <ToC tableOfContents={tableOfContents} version={version} path={path} />
             )}
           </div>
         </div>
@@ -358,9 +358,11 @@ function Version({
 function ToC({
   tableOfContents,
   version,
+  path
 }: {
   tableOfContents: TableOfContents;
   version: string | undefined;
+  path: string;
 }) {
   return (
     <div className="pt-2 pb-8 h-0 flex-1 flex flex-col overflow-y-auto">
@@ -374,7 +376,7 @@ function ToC({
                     href="/[identifier]/[...path]"
                     as={`/manual${version ? `@${version}` : ""}/${slug}`}
                   >
-                    <a className="text-gray-900 hover:text-gray-600 font-normal">
+                    <a className={`${path === `/${slug}` ? "text-blue-600 hover:text-blue-500" : "text-gray-900 hover:text-gray-600"} font-bold`}>
                       {entry.name}
                     </a>
                   </Link>
@@ -389,7 +391,7 @@ function ToC({
                                 version ? `@${version}` : ""
                               }/${slug}/${childSlug}`}
                             >
-                              <a className="text-gray-900 hover:text-gray-600 font-normal">
+                              <a className={`${path === `/${slug}/${childSlug}` ? "text-blue-600 hover:text-blue-500" : "text-gray-900 hover:text-gray-600"} font-normal`}>
                                 {name}
                               </a>
                             </Link>

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -54,6 +54,13 @@ function Manual() {
   useEffect(() => {
     getTableOfContents(version ?? "master")
       .then(setTableOfContents)
+      .then(() =>
+        setTimeout(
+          () =>
+            document.getElementsByClassName("toc-active")[0].scrollIntoView(),
+          0
+        )
+      )
       .catch((e) => {
         console.error("Failed to fetch table of contents:", e);
         setTableOfContents(null);
@@ -387,7 +394,7 @@ function ToC({
                     <a
                       className={`${
                         path === `/${slug}`
-                          ? "text-blue-600 hover:text-blue-500"
+                          ? "text-blue-600 hover:text-blue-500 toc-active"
                           : "text-gray-900 hover:text-gray-600"
                       } font-bold`}
                     >
@@ -408,7 +415,7 @@ function ToC({
                               <a
                                 className={`${
                                   path === `/${slug}/${childSlug}`
-                                    ? "text-blue-600 hover:text-blue-500"
+                                    ? "text-blue-600 hover:text-blue-500 toc-active"
                                     : "text-gray-900 hover:text-gray-600"
                                 } font-normal`}
                               >

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -179,7 +179,11 @@ function Manual() {
                     />
                   </div>
                   {tableOfContents && (
-                    <ToC tableOfContents={tableOfContents} version={version} path={path} />
+                    <ToC
+                      tableOfContents={tableOfContents}
+                      version={version}
+                      path={path}
+                    />
                   )}
                 </div>
               </Transition>
@@ -210,7 +214,11 @@ function Manual() {
               />
             </div>
             {tableOfContents && (
-              <ToC tableOfContents={tableOfContents} version={version} path={path} />
+              <ToC
+                tableOfContents={tableOfContents}
+                version={version}
+                path={path}
+              />
             )}
           </div>
         </div>
@@ -358,7 +366,7 @@ function Version({
 function ToC({
   tableOfContents,
   version,
-  path
+  path,
 }: {
   tableOfContents: TableOfContents;
   version: string | undefined;
@@ -376,7 +384,13 @@ function ToC({
                     href="/[identifier]/[...path]"
                     as={`/manual${version ? `@${version}` : ""}/${slug}`}
                   >
-                    <a className={`${path === `/${slug}` ? "text-blue-600 hover:text-blue-500" : "text-gray-900 hover:text-gray-600"} font-bold`}>
+                    <a
+                      className={`${
+                        path === `/${slug}`
+                          ? "text-blue-600 hover:text-blue-500"
+                          : "text-gray-900 hover:text-gray-600"
+                      } font-bold`}
+                    >
                       {entry.name}
                     </a>
                   </Link>
@@ -391,7 +405,13 @@ function ToC({
                                 version ? `@${version}` : ""
                               }/${slug}/${childSlug}`}
                             >
-                              <a className={`${path === `/${slug}/${childSlug}` ? "text-blue-600 hover:text-blue-500" : "text-gray-900 hover:text-gray-600"} font-normal`}>
+                              <a
+                                className={`${
+                                  path === `/${slug}/${childSlug}`
+                                    ? "text-blue-600 hover:text-blue-500"
+                                    : "text-gray-900 hover:text-gray-600"
+                                } font-normal`}
+                              >
                                 {name}
                               </a>
                             </Link>


### PR DESCRIPTION
Fix #457
Fix #515
Related #514 

- Sync TOC scroll position with current page
- Also made first level headings bold for further distinction.
![lDsln5rgE0](https://user-images.githubusercontent.com/44045911/82112672-b0bd6900-9781-11ea-9487-7ed73204d4ab.gif)
