### PR TITLE
[WIP] Add link to view manual on GitHub

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -7,6 +7,7 @@ import {
   TableOfContents,
   getTableOfContents,
   getFileURL,
+  getDocURL,
 } from "../util/manual_utils";
 import Markdown from "./Markdown";
 import Transition from "./Transition";
@@ -278,7 +279,17 @@ function Manual() {
           >
             <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 pb-12 sm:pb-20">
               {content ? (
-                <Markdown source={content} canonicalURL={sourceURL} />
+                <div className="divide-y divide-gray-200">
+                  <Markdown source={content} canonicalURL={sourceURL} />
+                  <div className="pt-3">
+                    <a
+                      className="text-gray-500 hover:text-gray-400"
+                      href={getDocURL(version ?? "master", path)}
+                    >
+                      View on GitHub
+                    </a>
+                  </div>
+                </div>
               ) : (
                 <div className="w-full my-8">
                   <div className="w-4/5 sm:w-1/3 bg-gray-100 h-8"></div>

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -29,5 +29,5 @@ export function getFileURL(version: string, path: string) {
 }
 
 export function getDocURL(version: string, path: string) {
-  return `${docpath}${version}/docs${path}.md#readme`;
+  return `${docpath}${version}/docs${path}.md`;
 }

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -1,4 +1,5 @@
 const basepath = "https://raw.githubusercontent.com/denoland/deno/";
+const docpath = "https://github.com/denoland/deno/blob/";
 
 export interface TableOfContents {
   [slug: string]: {
@@ -25,4 +26,8 @@ export async function getTableOfContents(
 
 export function getFileURL(version: string, path: string) {
   return `${basepath}${version}/docs${path}.md`;
+}
+
+export function getDocURL(version: string, path: string) {
+  return `${docpath}${version}/docs${path}.md#readme`;
 }


### PR DESCRIPTION
Fix #516 
`target="_blank"` can be added, request for comments.
![6udaX9c8dq](https://user-images.githubusercontent.com/44045911/82114858-c470cb80-9791-11ea-8905-832c5dc1821f.gif)
