### PR TITLE
Use CDN when fetching source files

### DIFF
--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -13,6 +13,6 @@ test("get introduction file", async () => {
   expect(
     getFileURL("f184332c09c851faac50f598d29ebe4426e05464", "/introduction")
   ).toEqual(
-    "https://cdn.jsdelivr.net/denoland/deno@f184332c09c851faac50f598d29ebe4426e05464/docs/introduction.md"
+    "https://cdn.jsdelivr.net/gh/denoland/deno@f184332c09c851faac50f598d29ebe4426e05464/docs/introduction.md"
   );
 });

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -13,6 +13,6 @@ test("get introduction file", async () => {
   expect(
     getFileURL("f184332c09c851faac50f598d29ebe4426e05464", "/introduction")
   ).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/f184332c09c851faac50f598d29ebe4426e05464/docs/introduction.md"
+    "https://cdn.jsdelivr.net/denoland/deno@f184332c09c851faac50f598d29ebe4426e05464/docs/introduction.md"
   );
 });

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -1,4 +1,4 @@
-const basepath = "https://raw.githubusercontent.com/denoland/deno/";
+const basepath = "https://cdn.jsdelivr.net/gh/denoland/deno";
 
 export interface TableOfContents {
   [slug: string]: {
@@ -12,7 +12,7 @@ export interface TableOfContents {
 export async function getTableOfContents(
   version: string
 ): Promise<TableOfContents> {
-  const res = await fetch(`${basepath}${version}/docs/toc.json`);
+  const res = await fetch(`${basepath}@${version}/docs/toc.json`);
   if (res.status !== 200) {
     throw Error(
       `Got an error (${
@@ -24,5 +24,5 @@ export async function getTableOfContents(
 }
 
 export function getFileURL(version: string, path: string) {
-  return `${basepath}${version}/docs${path}.md`;
+  return `${basepath}@${version}/docs${path}.md`;
 }

--- a/util/registries/deno_std.test.ts
+++ b/util/registries/deno_std.test.ts
@@ -13,25 +13,25 @@ const testEntry = new DenoStdEntry(testDbEntry);
 
 test("source url", () => {
   expect(testEntry.getSourceURL("/index.js", "0.50.0")).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/std/0.50.0/std/index.js"
+    "https://cdn.jsdelivr.net/gh/denoland/deno@std/0.50.0/std/index.js"
   );
 });
 
 test("source url with commit hash", () => {
   expect(testEntry.getSourceURL("/index.js", "a1cd4f")).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/a1cd4f/std/index.js"
+    "https://cdn.jsdelivr.net/gh/denoland/deno@a1cd4f/std/index.js"
   );
 });
 
 test("source url with default version", () => {
   expect(testEntry.getSourceURL("/index.js", undefined)).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/master/std/index.js"
+    "https://cdn.jsdelivr.net/gh/denoland/deno@master/std/index.js"
   );
 });
 
 test("source url with empty path", () => {
   expect(testEntry.getSourceURL("", "0.50.0")).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/std/0.50.0/std"
+    "https://cdn.jsdelivr.net/gh/denoland/deno@std/0.50.0/std"
   );
 });
 

--- a/util/registries/deno_std.ts
+++ b/util/registries/deno_std.ts
@@ -32,10 +32,7 @@ export class DenoStdEntry implements Entry {
   }
 
   getSourceURL(path: string, version?: string): string {
-    return stdEntry.getSourceURL(
-      path,
-      version ? stdVersion(version) : undefined
-    );
+    return stdEntry.getCDNURL(path, version ? stdVersion(version) : undefined);
   }
   getRepositoryURL(path: string, version?: string): string {
     return stdEntry.getRepositoryURL(

--- a/util/registries/github.ts
+++ b/util/registries/github.ts
@@ -30,6 +30,11 @@ export class GithubEntry implements Entry {
       version ?? this.defaultVersion ?? "master"
     }${this.path ?? ""}${path}`;
   }
+  getCDNURL(path: string, version?: string): string {
+    return `https://cdn.jsdelivr.net/gh/${this.owner}/${this.repo}@${
+      version ?? this.defaultVersion ?? "master"
+    }${this.path ?? ""}${path}`;
+  }
   getRepositoryURL(path: string, version?: string): string {
     return `https://github.com/${this.owner}/${this.repo}/tree/${
       version ?? this.defaultVersion ?? "master"


### PR DESCRIPTION
Currently we are using `raw.githubusercontent.com` to fetch source files **in browsers**. However, some people (e.g. in Mainland China) may have problems accessing the resources. Using a CDN both solves the inconvenience and accelerates browsing.

I suggest using [jsDelivr](https://www.jsdelivr.com/) given it is widely used and works in Mainland China.

This PR:

- Use jsDelivr when **browsers** fetch **manual** files
- Use jsDelivr when **browsers** fetch **registry** files

If you think the change only benefits particular people, we can make it a switch.