### PR TITLE
add router

### DIFF
--- a/database.json
+++ b/database.json
@@ -1342,6 +1342,12 @@
     "repo": "noble-ripemd160",
     "desc": "RIPEMD160, a cryptographic hash function."
   },
+  "router": {
+    "type": "github",
+    "owner": "zhmushan",
+    "repo": "router",
+    "desc": "A high-performance basic router works everywhere."
+  },
   "rsync_parser": {
     "type": "github",
     "owner": "daniel-araujo",


### PR DESCRIPTION
Stripped from `zhmushan/abc`, intending to become a universal base router for both browser and server.