### PR TITLE
Small tweaks

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -52,7 +52,7 @@ function Manual() {
   Router.events.on("routeChangeComplete", () =>
     manualEl.current?.scrollTo(0, 0)
   );
-                   
+
   useEffect(() => {
     if (showSidebar) {
       scrollTOCIntoView();

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -45,6 +45,9 @@ function Manual() {
   const [showSidebar, setShowSidebar] = useState<boolean>(false);
 
   Router.events.on("routeChangeStart", () => setShowSidebar(false));
+  Router.events.on("routeChangeComplete", () =>
+    document.getElementsByClassName("manual")[0].scrollTo(0, 0)
+  );
 
   const [
     tableOfContents,
@@ -294,7 +297,7 @@ function Manual() {
           </div>
 
           <main
-            className="flex-1 relative z-0 overflow-y-auto focus:outline-none"
+            className="flex-1 relative z-0 overflow-y-auto focus:outline-none manual"
             tabIndex={0}
           >
             <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 pb-12 sm:pb-20">

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter, Router } from "next/router";
@@ -45,8 +45,11 @@ function Manual() {
   const [showSidebar, setShowSidebar] = useState<boolean>(false);
 
   Router.events.on("routeChangeStart", () => setShowSidebar(false));
+
+  const manualEl = useRef<HTMLElement>(null);
+
   Router.events.on("routeChangeComplete", () =>
-    document.getElementsByClassName("manual")[0].scrollTo(0, 0)
+    manualEl.current?.scrollTo(0, 0)
   );
 
   const [
@@ -297,8 +300,9 @@ function Manual() {
           </div>
 
           <main
-            className="flex-1 relative z-0 overflow-y-auto focus:outline-none manual"
+            className="flex-1 relative z-0 overflow-y-auto focus:outline-none"
             tabIndex={0}
+            ref={manualEl}
           >
             <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 pb-12 sm:pb-20">
               {content ? (

--- a/components/app.css
+++ b/components/app.css
@@ -51,3 +51,8 @@ ol.nested li:before {
 .deno-offwhite .deno-inlinecode {
   @apply bg-gray-200;
 }
+
+.prism-code {
+  tab-size: 4;
+  -moz-tab-size: 4;
+}

--- a/components/app.css
+++ b/components/app.css
@@ -53,6 +53,6 @@ ol.nested li:before {
 }
 
 .prism-code {
-  tab-size: 4;
-  -moz-tab-size: 4;
+  tab-size: 2;
+  -moz-tab-size: 2;
 }


### PR DESCRIPTION
Fix #208 

- Use 2 spaces for tabs
- Reset scroll position (scroll to top) when navigating through manuals