### PR TITLE
Fix misleading size for directories

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -513,8 +513,12 @@ function DirectoryListing(props: {
                         </td>
                         <td className="px-4 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500 text-right">
                           {
-                          // TODO(kennanseno): Directory should pull total size inside it. 
-                          entry.type === "dir" ? "" : (entry.size !== undefined ? bytesToSize(entry.size) : "N/A")
+                            /** TODO(kennanseno): Directory should pull total size inside it.  */
+                            entry.type === "dir"
+                              ? ""
+                              : entry.size !== undefined
+                              ? bytesToSize(entry.size)
+                              : "N/A"
                           }
                         </td>
                       </tr>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -512,9 +512,10 @@ function DirectoryListing(props: {
                           {entry.name}
                         </td>
                         <td className="px-4 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500 text-right">
-                          {entry.size !== undefined
-                            ? bytesToSize(entry.size)
-                            : "N/A"}
+                          {
+                          // TODO(kennanseno): Directory should pull total size inside it. 
+                          entry.type === "dir" ? "" : (entry.size !== undefined ? bytesToSize(entry.size) : "N/A")
+                          }
                         </td>
                       </tr>
                     </Link>


### PR DESCRIPTION
Not showing anything on dir paths for now rather than 0B which is misleading.

Realistically we should pull total size inside a directory but we've bigger fish to fry.