### PR TITLE
Add GraphQL Port to Deno

### DIFF
--- a/database.json
+++ b/database.json
@@ -839,6 +839,12 @@
     "repo": "gentleRpc",
     "desc": "JSON-RPC 2.0 TypeScript library for deno and browser."
   },
+  "graphql": {
+    "type": "github",
+    "owner": "CreatCodeBuild",
+    "repo": "graphql-projects",
+    "desc": "A Deno GraphQL port"
+  },
   "gusano": {
     "type": "github",
     "owner": "krthr",


### PR DESCRIPTION
Port GraphQL to Deno.
```js
import { default as graphql } from "https://creatcodebuild.github.io/graphql-projects/deno-graphql-port/dist/graphql.js";
```

One question, the repo is https://github.com/CreatCodeBuild/graphql-projects which is a mono repo for multiple JavaScript (Node + Deno hybrid) projects. Should I register different names in this JSON to indicate different Deno projects?