### PR TITLE
feat: Add opine web framework to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -1437,6 +1437,12 @@
     "repo": "deno-open",
     "desc": "A package for opening URLs, files and executables."
   },
+  "opine": {
+    "type": "github",
+    "owner": "asos-craigmorten",
+    "repo": "opine",
+    "desc": "Fast, minimalist web framework for Deno ported from ExpressJS."
+  },
   "panoptes": {
     "type": "github",
     "owner": "TokenChingy",


### PR DESCRIPTION
This PR adds `opine` - _Fast, minimalist web framework for Deno ported from ExpressJS_ - to the Denoland third party module database.