### PR TITLE
Add `airtable-deno`

### DIFF
--- a/database.json
+++ b/database.json
@@ -11,6 +11,12 @@
     "repo": "actdb",
     "desc": "A simple nosql reactive db or database."
   },
+  "airtable": {
+    "type": "github",
+    "owner": "grikomsn",
+    "repo": "airtable-deno",
+    "desc": "Unofficial Airtable Client for Deno"
+  },
   "alosaur": {
     "type": "github",
     "owner": "irustm",


### PR DESCRIPTION
Hi there! 👋 

This PR adds [`airtable-deno`](https://github.com/grikomsn/airtable-deno) to [`deno.land/x`](https://deno.land/x) database. Let me know if there's anything I should change.