### PR TITLE
Update database.json: supports-color

### DIFF
--- a/database.json
+++ b/database.json
@@ -1980,7 +1980,7 @@
     "repo": "strcolors.ts",
     "desc": "FMT String Extensions for Deno"
   },
-  "supports-color": {
+  "supports_color": {
     "type": "github",
     "owner": "frunkad",
     "repo": "supports-color",

--- a/database.json
+++ b/database.json
@@ -1980,6 +1980,12 @@
     "repo": "strcolors.ts",
     "desc": "FMT String Extensions for Deno"
   },
+  "supports-color": {
+    "type": "github",
+    "owner": "frunkad",
+    "repo": "supports-color",
+    "desc": "Detect whether a terminal supports color (basic, 256 or 16m)"
+  },
   "supreme_api": {
     "type": "github",
     "owner": "desire",


### PR DESCRIPTION
Port for [supports-color](https://www.npmjs.com/package/supports-color) module.

Checks whether the terminal supports basic 10 colors, 256 colors or 16 million colors.