### PR TITLE
Add reactive-js to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -1853,6 +1853,12 @@
     "repo": "deno_random_interval",
     "desc": "deno random interval"
   },
+  "reactive-js": {
+    "type": "github",
+    "owner": "bordoley",
+    "repo": "reactive-js",
+    "desc": "Functional reactive programming including Observables, Bi-directional asynchronous streams, and utilities"
+  },
   "readline": {
     "type": "github",
     "owner": "vslinko",

--- a/database.json
+++ b/database.json
@@ -1853,7 +1853,7 @@
     "repo": "deno_random_interval",
     "desc": "deno random interval"
   },
-  "reactive-js": {
+  "reactive": {
     "type": "github",
     "owner": "bordoley",
     "repo": "reactive-js",


### PR DESCRIPTION
I've been working on a very complete functional reactive programming library which implements  Observable and other bi-directional asynchronous stream types for modeling I/O etc. The library supports Deno out of the box and I'd like to list it on deno.land. 