### PR TITLE
Updated .gitignore for ignoring vscode settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ worker/script.js
 
 .now
 .vercel
+
+# vscode settings
+.vscode


### PR DESCRIPTION
I noticed this issue while working on another fix but I think we need to take the standard `.gitignore` file from the create-react-app.