### PR TITLE
Updated repo name of Array-Utils in GitHub

### DIFF
--- a/database.json
+++ b/database.json
@@ -75,7 +75,7 @@
   "arrays": {
     "type": "github",
     "owner": "damianperera",
-    "repo": "array-utils",
+    "repo": "ts-arrays",
     "desc": "Provides support for common Array operations."
   },
   "ask": {


### PR DESCRIPTION
Updating the repository name of the https://deno.land/x/arrays module from `damianperera/array-utils` to `damianperera/ts-arrays`