### PR TITLE
Add hkatzdev/secure-compare to the database

### DIFF
--- a/database.json
+++ b/database.json
@@ -2190,7 +2190,7 @@
     "repo": "noble-secp256k1",
     "desc": "secp256k1, an elliptic curve that could be used for assymetric encryption and ECDSA signature scheme."
   },
-  "secure-compare": {
+  "secure_compare": {
     "type": "github",
     "owner": "hkatzdev",
     "repo": "secure-compare",

--- a/database.json
+++ b/database.json
@@ -2190,6 +2190,12 @@
     "repo": "noble-secp256k1",
     "desc": "secp256k1, an elliptic curve that could be used for assymetric encryption and ECDSA signature scheme."
   },
+  "secure-compare": {
+    "type": "github",
+    "owner": "hkatzdev",
+    "repo": "secure-compare",
+    "desc": "Constant-time comparison algorithm to prevent timing attacks (Deno edition)"
+  },
   "semver": {
     "type": "github",
     "owner": "justjavac",


### PR DESCRIPTION
Adds a secure-compare module to the 3rd party list. Heavily based on [secure-compare](https://github.com/vadimdemedes/secure-compare) which on turn takes code from [cryptiles](https://github.com/hapijs/cryptiles). More or less just the Node.js secure-compare but with typescript types and Deno tests.