### PR TITLE
feat: Add permission-guard to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -1473,6 +1473,12 @@
     "repo": "PerlinNoise-Deno",
     "desc": "A simple to use perlin noise module for typescript."
   },
+  "permission-guard": {
+    "type": "github",
+    "owner": "asos-craigmorten",
+    "repo": "permission-guard",
+    "desc": "A zero-dependency, minimal permission guard."
+  },
   "pg_format": {
     "type": "github",
     "owner": "grantcarthew",

--- a/database.json
+++ b/database.json
@@ -1473,7 +1473,7 @@
     "repo": "PerlinNoise-Deno",
     "desc": "A simple to use perlin noise module for typescript."
   },
-  "permission-guard": {
+  "permissionGuard": {
     "type": "github",
     "owner": "asos-craigmorten",
     "repo": "permission-guard",


### PR DESCRIPTION
This PR adds `permission-guard` - "A zero-dependency, minimal permission guard for Deno to prevent overly permissive execution of your applications" - to the Denoland third party module database.