### PR TITLE
Revert "feat: added stars for github and download badges for npm"

### DIFF
--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -128,27 +128,6 @@ const ThirdPartyRegistryList = () => {
                                 </div>
                               </div>
                               <div>
-                                {entries[name]?.type === "github" ? (
-                                  <img
-                                    src={`https://img.shields.io/github/stars/${
-                                      entries[name]?.owner ?? ""
-                                    }/${
-                                      entries[name]?.repo ?? ""
-                                    }.svg?style=flat`}
-                                    alt={`${entries[name]?.owner ?? ""}/${
-                                      entries[name]?.owner ?? ""
-                                    }`}
-                                  />
-                                ) : entries[name]?.type === "npm" ? (
-                                  <img
-                                    src={`https://img.shields.io/npm/dm/${
-                                      entries[name]?.package ?? ""
-                                    }.svg?style=flat`}
-                                    alt={`${entries[name]?.package ?? ""}`}
-                                  />
-                                ) : null}
-                              </div>
-                              <div>
                                 <svg
                                   className="h-5 w-5 text-gray-400"
                                   fill="currentColor"

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -5,7 +5,7 @@ import { GithubEntry, GithubDatabaseEntry } from "./registries/github";
 import { DenoStdEntry, DenoStdDatabaseEntry } from "./registries/deno_std";
 import { URLEntry, URLDatabaseEntry } from "./registries/url";
 import { NPMEntry, NPMDatabaseEntry } from "./registries/npm";
-import { Entry } from "./registries";
+import { Entry, DatabaseEntry } from "./registries";
 
 function findDatabaseEntry(
   name: string
@@ -86,9 +86,4 @@ export function isReadme(filename: string) {
   );
 }
 
-export const entries = (DATABASE as unknown) as {
-  [name: string]: GithubDatabaseEntry &
-    DenoStdDatabaseEntry &
-    URLDatabaseEntry &
-    NPMDatabaseEntry;
-};
+export const entries = DATABASE as { [name: string]: DatabaseEntry };


### PR DESCRIPTION
Reverts denoland/deno_website2#603

A lot of the badges are not actually displayed because of rate limits:
![image](https://user-images.githubusercontent.com/7829205/83007436-f7c61c80-a013-11ea-8949-7bfec63e1b53.png)

Also this is probably causing a lot of strain on `img.shields.io` because we request ~400 badges for every /x load. We should come up with a different solution that includes caching on our side.

Ref #848