### PR TITLE
Add deno_notify to third party modules

### DIFF
--- a/database.json
+++ b/database.json
@@ -735,6 +735,12 @@
     "repo": "deno_minimist",
     "desc": "💾 Parses command line arguments. Port & rewrite of the node library minimist"
   },
+  "deno_notify": {
+    "type": "github",
+    "owner": "PandawanFr",
+    "repo": "deno_notify",
+    "desc": "Send desktop notifications on all platforms in Deno"
+  },
   "deno_pixabay": {
     "type": "github",
     "owner": "yeukfei02",


### PR DESCRIPTION
Note: My readme currently mentions using denopkg.com but I will switch them over to deno.land/x if this PR is approved.