### PR TITLE
Add `dep`, a dependency management tool.

### DIFF
--- a/database.json
+++ b/database.json
@@ -934,6 +934,12 @@
     "repo": "denv",
     "desc": "A module similar to dotEnv, but for Deno"
   },
+  "dep": {
+    "type": "github",
+    "owner": "denodep",
+    "repo": "cli",
+    "desc": "Deno dependency management tool."
+  },
   "deps": {
     "type": "github",
     "owner": "denosaurs",


### PR DESCRIPTION
Using [import maps](https://deno.land/manual/linking_to_external_code/import_maps) to manage deno project dependencies.
Also provide services for publishing and hosting deno modules.