### PR TITLE
Move Markdown link on top of page and use Github icon

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -360,6 +360,24 @@ function Manual() {
             <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 pb-12 sm:pb-20">
               {content ? (
                 <>
+                  <a
+                    href={getDocURL(version ?? "master", path)}
+                    className="text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out float-right mt-1"
+                  >
+                    <span className="sr-only">GitHub</span>
+                    <svg
+                      className="h-6 w-6 inline"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>Github | Deno</title>
+                      <path
+                        fillRule="evenodd"
+                        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </a>
                   <Markdown
                     source={content}
                     displayURL={location.origin + "/manual" + path}
@@ -386,14 +404,6 @@ function Manual() {
                         </a>
                       </Link>
                     )}
-                  </div>
-                  <div className="pt-2 clear-both">
-                    <a
-                      className="text-gray-500 hover:text-gray-400 font-normal float-right"
-                      href={getDocURL(version ?? "master", path)}
-                    >
-                      View on GitHub
-                    </a>
                   </div>
                 </>
               ) : (


### PR DESCRIPTION
Improves markdown links as specified in https://github.com/denoland/deno_website2/issues/797

Screenshots:
![Screenshot 2020-05-30 at 19 21 05](https://user-images.githubusercontent.com/7852866/83336451-6bce2200-a2ab-11ea-8741-3e6029c8b16a.png)

Mobile:
![Screenshot 2020-05-30 at 19 21 31](https://user-images.githubusercontent.com/7852866/83336455-6ec91280-a2ab-11ea-8e52-d2886d1cac06.png)
