### PR TITLE
add jozsefsallai/tbl

### DIFF
--- a/database.json
+++ b/database.json
@@ -2790,6 +2790,12 @@
     "repo": "deno-task-runner-v2",
     "desc": "deno-task-runner-v2"
   },
+  "tbl": {
+    "type": "github",
+    "owner": "jozsefsallai",
+    "repo": "tbl",
+    "desc": "Tiny and versatile command-line table generator."
+  },
   "tckimlik": {
     "type": "github",
     "owner": "serkanalgur",


### PR DESCRIPTION
[tbl](https://github.com/jozsefsallai/tbl) is a command line table generator. It aims to be tiny, dependency-free, and versatile.