### PR TITLE
Add deno-aws-sign-v4 back to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -633,6 +633,12 @@
     "repo": "deno_app_setuper",
     "desc": "A CLI to setup apps like a Create React App."
   },
+  "deno_aws_sign_v4": {
+    "type": "github",
+    "owner": "silver-xu",
+    "repo": "deno-aws-sign-v4",
+    "desc": "Generates AWS Signature V4 for AWS low-level REST APIs"
+  },
   "deno_check_thai_pid": {
     "type": "github",
     "owner": "thiti-y",


### PR DESCRIPTION
This was removed by #837 after being added in #689. It appears like the repository owned had changed their GitHub username, or perhaps it was added incorrectly in the first place.

Refs:

cde8674 Removed repos which does not exists (#837)
a5fd875 Adding deno-aws-sign-v4 (#689)

cc @ry @Swap76 @silver-xu 