### PR TITLE
feat: add superdeno to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -2736,6 +2736,12 @@
     "repo": "strcolors.ts",
     "desc": "FMT String Extensions for Deno"
   },
+  "superdeno": {
+    "type": "github",
+    "owner": "asos-craigmorten",
+    "repo": "superdeno",
+    "desc": "HTTP assertions for Deno made easy via superagent."
+  },
   "supports_color": {
     "type": "github",
     "owner": "frunkad",


### PR DESCRIPTION
This PR adds [`superdeno`](https://github.com/asos-craigmorten/superdeno) - _HTTP assertions for Deno made easy via superagent_ - to the Denoland third party module database.

i.e. a port of <https://github.com/visionmedia/supertest> for Deno.