### PR TITLE
add often/ipapi

### DIFF
--- a/database.json
+++ b/database.json
@@ -1687,17 +1687,17 @@
     "repo": "deno-ip",
     "desc": "Detect your IP address and/or fetch geolocation data for an IP address, domain or email via ipify.org"
   },
-  "ipapi": {
-    "type": "github",
-    "owner": "often",
-    "repo": "ipapi",
-    "desc": "Simple ip-api.com API wrapper for Deno."
-  },
   "ip_details": {
     "type": "github",
     "owner": "guptamohit004",
     "repo": "ip_details",
     "desc": " Get All information of an IP address."
+  },
+  "ipapi": {
+    "type": "github",
+    "owner": "often",
+    "repo": "ipapi",
+    "desc": "Simple ip-api.com API wrapper for Deno."
   },
   "iro": {
     "type": "github",

--- a/database.json
+++ b/database.json
@@ -1675,6 +1675,12 @@
     "repo": "deno-ip",
     "desc": "Detect your IP address and/or fetch geolocation data for an IP address, domain or email via ipify.org"
   },
+  "ipapi": {
+    "type": "github",
+    "owner": "often",
+    "repo": "ipapi",
+    "desc": "Simple ip-api.com API wrapper for Deno."
+  },
   "iro": {
     "type": "github",
     "owner": "jozsefsallai",


### PR DESCRIPTION
"ipapi" is a simple API wrapper for ip-api.com, it aims to make IP geolocation easy, without using databases such as maxmind, ip2location, db-ip, etc...
the wrapper has full API coverage and is beginner friendly :)