### PR TITLE
feat: add superoak to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -2892,6 +2892,12 @@
     "repo": "superdeno",
     "desc": "HTTP assertions for Deno made easy via superagent."
   },
+  "superoak": {
+    "type": "github",
+    "owner": "asos-craigmorten",
+    "repo": "superoak",
+    "desc": "HTTP assertions for Oak made easy via superdeno."
+  },
   "supports_color": {
     "type": "github",
     "owner": "frunkad",


### PR DESCRIPTION
This PR adds [`superoak`](https://github.com/asos-craigmorten/superoak) - _HTTP assertions for Deno made easy via SuperDeno_ - to the DenoLand third party module database.