### PR TITLE
Change moment repo in database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -2135,9 +2135,9 @@
   },
   "moment": {
     "type": "github",
-    "owner": "lisniuse",
+    "owner": "MilesWells",
     "repo": "deno_moment",
-    "desc": "The Moment.ts library for Deno that was ported from moment@2.24.0, Hope you like it."
+    "desc": "The Moment.ts library for Deno that was ported from moment@2.24.0 and includes typedefs."
   },
   "mongo": {
     "type": "github",


### PR DESCRIPTION
I wanted to add the typedefs to the existing repo but [my PR](https://github.com/lisniuse/deno_moment/pull/1) has gone ignored so instead here's a PR to point to my updated fork instead of lisniuse's original.