### PR TITLE
add makehelp

### DIFF
--- a/database.json
+++ b/database.json
@@ -2013,6 +2013,12 @@
     "repo": "mandarinets",
     "desc": "A MVC Framework built on Typescript that runs on Deno. Components, Dependency Injection, Sessions, Security and more."
   },
+  "makehelp": {
+    "type": "github",
+    "owner": "konsumer",
+    "repo": "deno-make-help",
+    "desc": "A very simple help-provider for deno makefiles"
+  },
   "markdown": {
     "type": "github",
     "owner": "ubersl0th",

--- a/database.json
+++ b/database.json
@@ -2002,22 +2002,22 @@
     "desc": "Get the MAC addresses of the current machine."
   },
   "machine_id": {
-    "type": "github",
+    "desc": "Get the unique ID of the current machine",
     "owner": "axetroy",
     "repo": "deno_machine_id",
-    "desc": "Get the unique ID of the current machine"
+    "type": "github"
+  },
+  "makehelp": {
+    "desc": "A very simple help-provider for deno makefiles",
+    "owner": "konsumer",
+    "repo": "deno-make-help",
+    "type": "github"
   },
   "mandarinets": {
     "type": "github",
     "owner": "mandarineorg",
     "repo": "mandarinets",
     "desc": "A MVC Framework built on Typescript that runs on Deno. Components, Dependency Injection, Sessions, Security and more."
-  },
-  "makehelp": {
-    "type": "github",
-    "owner": "konsumer",
-    "repo": "deno-make-help",
-    "desc": "A very simple help-provider for deno makefiles"
   },
   "markdown": {
     "type": "github",


### PR DESCRIPTION
This adds [`makehelp`](https://github.com/konsumer/deno-make-help) 3rd-party module, which is a very simple script to parse your Makefile, and output help. I think this will be useful for people wishing to replace `npm run` with plain Makefiles.