### PR TITLE
Added fuse

### DIFF
--- a/database.json
+++ b/database.json
@@ -1518,6 +1518,12 @@
     "repo": "funky",
     "desc": "Bring the beloved Option<T>, Result<T, E> and other functional utilities into your next Deno masterpiece!"
   },
+  "fuse": {
+    "type": "github",
+    "owner": "krisk",
+    "repo": "Fuse",
+    "desc": "Fuse.js is a powerful, lightweight fuzzy-search library, with zero dependencies."
+  },
   "gardens": {
     "type": "github",
     "owner": "partheseas",


### PR DESCRIPTION
This adds the classic library https://github.com/krisk/Fuse

Here's a working preview of Fuse.js on repl.it: https://repl.it/@lunaroyster/Fusejs-deno

Import pattern:

```typescript
// @deno-types="https://raw.githubusercontent.com/krisk/Fuse/master/dist/fuse.d.ts"
import Fuse from 'https://raw.githubusercontent.com/krisk/Fuse/master/dist/fuse.esm.min.js'
```