### PR TITLE
feat: add opine-http-proxy to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -2495,6 +2495,12 @@
     "repo": "opine",
     "desc": "Fast, minimalist web framework for Deno ported from ExpressJS."
   },
+  "opineHttpProxy": {
+    "type": "github",
+    "owner": "asos-craigmorten",
+    "repo": "opine-http-proxy",
+    "desc": "Proxy middleware for Opine HTTP servers."
+  },
   "organ": {
     "type": "github",
     "owner": "denjucks",


### PR DESCRIPTION
This PR adds `opine-http-proxy` - _Proxy middleware for [Opine](https://github.com/asos-craigmorten/opine) HTTP servers._ - to the Denoland third party module database.