### PR TITLE
Change random thirdparty module filtering

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,13 +35,9 @@ for await (const req of s) {
     SimpleEntry[] | null
   >(null);
   useEffect(() => {
-    const thirdPartySelection = [];
-    for (let i = 0; i < NUM_THIRD_PARTY; i++) {
-      const s = Math.floor(thirdPartyEntryPool.length * Math.random());
-      thirdPartySelection.push(thirdPartyEntryPool[s]);
-      thirdPartyEntryPool.splice(s, 1);
-    }
-    setThirdPartySelection(thirdPartySelection);
+    setThirdPartySelection(
+      RandomEntriesFromArray(thirdPartyEntryPool, NUM_THIRD_PARTY)
+    );
   }, []);
 
   return (
@@ -266,7 +262,13 @@ for await (const req of s) {
                 <h4 className="text-lg font-bold">{s.name}</h4>
                 <p
                   className="whitespace-normal break-words text-gray-700 mt-2 overflow-hidden"
-                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", display: "-webkit-box" }}
+                  style={{
+                    textOverflow: "ellipsis",
+                    minHeight: "4.5em",
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: "vertical",
+                    display: "-webkit-box",
+                  }}
                 >
                   {s.desc}
                 </p>
@@ -368,6 +370,19 @@ const InstallSection = () => {
   );
 };
 
+const RandomEntriesFromArray = (sourceArray: SimpleEntry[], count: number) => {
+  const source = sourceArray;
+  const selection = [];
+
+  for (let i = 0; i < Math.min(count, source.length); i++) {
+    const s = Math.floor(sourceArray.length * Math.random());
+    selection.push(sourceArray[s]);
+    source.splice(s, 1);
+  }
+
+  return selection;
+};
+
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const thirdPartyEntries: SimpleEntry[] = [];
 
@@ -386,15 +401,14 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     }
   });
 
-  const thirdPartyEntryPool = [];
-  for (let i = 0; i < POOL_NUM_THIRD_PARTY; i++) {
-    const s = Math.floor(thirdPartyEntries.length * Math.random());
-    thirdPartyEntryPool.push(thirdPartyEntries[s]);
-    thirdPartyEntries.splice(s, 1);
-  }
-
   return {
-    props: { thirdPartyEntryPool, latestStd: stdVersions[0] },
+    props: {
+      thirdPartyEntryPool: RandomEntriesFromArray(
+        thirdPartyEntries,
+        POOL_NUM_THIRD_PARTY
+      ),
+      latestStd: stdVersions[0],
+    },
   };
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -265,7 +265,7 @@ for await (const req of s) {
                 <h4 className="text-lg font-bold">{s.name}</h4>
                 <p
                   className="whitespace-normal break-words text-gray-700 mt-2 overflow-hidden"
-                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", webkitLineClamp: "3", webkitBoxOrient: "vertical", display: "-webkit-box" }}
+                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", WebkitLineClamp: "3", WebkitBoxOrient: "vertical", display: "-webkit-box" }}
                 >
                   {s.desc}
                 </p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -265,7 +265,7 @@ for await (const req of s) {
                 <h4 className="text-lg font-bold">{s.name}</h4>
                 <p
                   className="whitespace-normal break-words text-gray-700 mt-2 overflow-hidden"
-                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", WebkitLineClamp: "3", WebkitBoxOrient: "vertical", display: "-webkit-box" }}
+                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", display: "-webkit-box" }}
                 >
                   {s.desc}
                 </p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,8 +21,9 @@ interface HomeProps {
 }
 
 const NUM_THIRD_PARTY = 12;
+const POOL_NUM_THIRD_PARTY = 50;
 
-const Home: NextPage<HomeProps> = ({ thirdPartyEntries, latestStd }) => {
+const Home: NextPage<HomeProps> = ({ thirdPartyEntryPool, latestStd }) => {
   const complexExampleProgram = `import { serve } from "https://deno.land/std@${latestStd}/http/server.ts";
 const s = serve({ port: 8000 });
 console.log("http://localhost:8000/");
@@ -36,9 +37,9 @@ for await (const req of s) {
   useEffect(() => {
     const thirdPartySelection = [];
     for (let i = 0; i < NUM_THIRD_PARTY; i++) {
-      const s = Math.floor(thirdPartyEntries.length * Math.random());
-      thirdPartySelection.push(thirdPartyEntries[s]);
-      thirdPartyEntries.splice(s, 1);
+      const s = Math.floor(thirdPartyEntryPool.length * Math.random());
+      thirdPartySelection.push(thirdPartyEntryPool[s]);
+      thirdPartyEntryPool.splice(s, 1);
     }
     setThirdPartySelection(thirdPartySelection);
   }, []);
@@ -385,8 +386,15 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     }
   });
 
+  const thirdPartyEntryPool = [];
+  for (let i = 0; i < POOL_NUM_THIRD_PARTY; i++) {
+    const s = Math.floor(thirdPartyEntries.length * Math.random());
+    thirdPartyEntryPool.push(thirdPartyEntries[s]);
+    thirdPartyEntries.splice(s, 1);
+  }
+
   return {
-    props: { thirdPartyEntries, latestStd: stdVersions[0] },
+    props: { thirdPartyEntryPool, latestStd: stdVersions[0] },
   };
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,7 +16,7 @@ interface SimpleEntry {
   desc: string;
 }
 interface HomeProps {
-  thirdPartyEntries: SimpleEntry[];
+  thirdPartyEntryPool: SimpleEntry[];
   latestStd: string;
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -264,8 +264,8 @@ for await (const req of s) {
               >
                 <h4 className="text-lg font-bold">{s.name}</h4>
                 <p
-                  className="whitespace-normal break-words text-gray-700 mt-2"
-                  style={{ textOverflow: "ellipsis" }}
+                  className="whitespace-normal break-words text-gray-700 mt-2 overflow-hidden"
+                  style={{ textOverflow: "ellipsis", minHeight: "4.5em", webkitLineClamp: "3", webkitBoxOrient: "vertical", display: "-webkit-box" }}
                 >
                   {s.desc}
                 </p>
@@ -374,8 +374,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     const entry = entries[name];
     if (
       entry &&
-      entry.desc.length >= 70 &&
-      entry.desc.length <= 90 &&
+      entry.desc.length >= 10 &&
       name !== "std" &&
       name !== "std_old"
     ) {


### PR DESCRIPTION
The current filter only chooses modules, which description's length is between 70 and 90. I assume it is to make sure they have a 3 line description on the page, so truncation doesnt cause a problem

I checked it, and currently only 131 entries satisfy this, out of 629 (20%).
As 12 modules are shown on the page on each load, the modules shown repeat quite often.

I tought it might be good to have all modules in the pool.
Of course with this there can be too long desctiptions, so i truncated them using `-webkit-line-clamp`. [caniuse](https://caniuse.com/#search=-webkit-line-clamp) tells its well supported.
I tried Chrome, Firefox, Edge, IE. All work except IE of course (but the current page has problems too)

I understand this may be a design and UI decision, so feel free to close this PR.