### PR TITLE
Add simple_slackbot to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -3200,6 +3200,12 @@
     "repo": "short_uuid",
     "desc": "Generate random or sequential UUID of any length."
   },
+  "simple_slackbot": {
+    "type": "github",
+    "owner": "cesar-faria",
+    "repo": "simple_slackbot",
+    "desc": "A simple wrapper for Slack API."
+  },
   "simple_type_assert": {
     "type": "github",
     "owner": "KSXGitHub",


### PR DESCRIPTION
Simple Slackbot is a simple wrapper for Slack API.