### PR TITLE
Add encoding_wasm to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -1706,6 +1706,13 @@
     "desc": "Encode a URL to a percent-encoded form, excluding already-encoded sequences. Build for Deno.",
     "default_version": "master"
   },
+  "encoding_wasm": {
+    "type": "github",
+    "owner": "marcosc90",
+    "repo": "encoding-wasm",
+    "desc": "Encodings using WASM",
+    "default_version": "master"
+  },
   "ende": {
     "type": "github",
     "owner": "rsp",


### PR DESCRIPTION
Was working on base64 streaming and notice that base64 from `std/encoding` is very slow, so [implemented](https://github.com/marcosc90/encoding-wasm) using WASM to speed things up.

decoding an `8mb` image takes `~1s` with `std/encoding` and `~26ms` with WASM on my computer.

I'm mentioning this in case we want to add it to std as we did with hashes.