### PR TITLE
fix: changed default branch of opine repo

### DIFF
--- a/database.json
+++ b/database.json
@@ -3139,7 +3139,7 @@
     "owner": "asos-craigmorten",
     "repo": "opine-http-proxy",
     "desc": "Proxy middleware for Opine HTTP servers.",
-    "default_version": "master"
+    "default_version": "main"
   },
   "organ": {
     "type": "github",


### PR DESCRIPTION
Default branch is changed for Opine.

<img width="2032" alt="Screenshot 2020-06-20 at 8 32 47 PM" src="https://user-images.githubusercontent.com/2510560/85204888-41650700-b335-11ea-8dc2-77959e7d1f0e.png">

<img width="2032" alt="Screenshot 2020-06-20 at 8 26 38 PM" src="https://user-images.githubusercontent.com/2510560/85204869-25f9fc00-b335-11ea-8722-2be8873f6fb3.png">
