### PR TITLE
fix: opine and superdeno have moved default branch to main.

### DIFF
--- a/database.json
+++ b/database.json
@@ -3158,7 +3158,7 @@
     "owner": "asos-craigmorten",
     "repo": "opine",
     "desc": "Fast, minimalist web framework for Deno ported from ExpressJS.",
-    "default_version": "master"
+    "default_version": "main"
   },
   "opineHttpProxy": {
     "type": "github",
@@ -4065,7 +4065,7 @@
     "owner": "asos-craigmorten",
     "repo": "superdeno",
     "desc": "HTTP assertions for Deno made easy via superagent.",
-    "default_version": "master"
+    "default_version": "main"
   },
   "superoak": {
     "type": "github",


### PR DESCRIPTION
Following:
- https://github.com/denoland/deno_website2/pull/1184
- https://github.com/denoland/deno_website2/pull/1186
- https://github.com/asos-craigmorten/opine/issues/19

This PR corrects the branch in the `database.json` for the [Opine](https://github.com/asos-craigmorten/opine) and [SuperDeno](https://github.com/asos-craigmorten/superdeno) to now point to `main`.