### PR TITLE
Added bigdenary

### DIFF
--- a/database.json
+++ b/database.json
@@ -288,6 +288,13 @@
     "desc": "Lightweight BGPView API wrapper.",
     "default_version": "master"
   },
+  "bigdenary": {
+    "type": "github",
+    "owner": "uzyn",
+    "repo": "bigdenary",
+    "desc": "Arbitrary-length decimal library, like bigdecimal or bignumber, but implemented natively with BigInt. Lightweight and lightning fast.",
+    "default_version": "master"
+  },
   "bigfloat": {
     "type": "github",
     "owner": "davidmartinez10",


### PR DESCRIPTION
BigDenary is an arbitrary-length decimal library, like bigdecimal or bignumber, but implemented natively with BigInt. Lightweight and lightning fast.