### PR TITLE
Add DenoHub to /x

### DIFF
--- a/database.json
+++ b/database.json
@@ -1279,6 +1279,13 @@
     "desc": "denoget installs executable deno script.",
     "default_version": "master"
   },
+  "denohub": {
+    "type": "github",
+    "owner": "ncplayz",
+    "repo": "denohub",
+    "desc": "A Github API v3 Client for Deno",
+    "default_version": "master"
+  },
   "denoliver": {
     "type": "github",
     "owner": "joakimunge",


### PR DESCRIPTION
I am adding a Work-In-Progress GitHub API v3 Client for Deno to the third party modules list. It can be found here: https://github.com/NCPlayz/DenoHub