### PR TITLE
Revert "fix: add padding to artworks"

### DIFF
--- a/pages/artwork.tsx
+++ b/pages/artwork.tsx
@@ -42,12 +42,12 @@ const ArtworkPage = () => {
 
 function Item({ artwork }: { artwork: Artwork }) {
   return (
-    <div className="p-2">
+    <div>
       <div className="flex justify-center">
         <img
           src={artwork.image}
           alt={artwork.alt}
-          className="rounded-md h-56"
+          className="rounded-md max-h-56"
         />
       </div>
       <div className="mt-3 text-xl font-semibold text-center">


### PR DESCRIPTION
Reverts denoland/deno_website2#1210

A unrelated change in this PR that changed`max-h-56` to `h-56` in makes wide image look squashed images on small screens: 
![image](https://user-images.githubusercontent.com/7829205/85465178-c572f500-b5a8-11ea-84b4-7a8634d9a6b7.png)

cc @ry @Qu4k