### PR TITLE
Fix artwork padding and aligning

### DIFF
--- a/pages/artwork.tsx
+++ b/pages/artwork.tsx
@@ -29,7 +29,7 @@ const ArtworkPage = () => {
             </a>
           </p>
         </div>
-        <div className="my-16 flex flex-row flex-wrap gap-16 justify-evenly">
+        <div className="my-16 flex flex-row flex-wrap gap-16 justify-evenly items-end">
           {ARTWORKS.map((artwork, i) => (
             <Item key={i} artwork={artwork} />
           ))}
@@ -42,7 +42,7 @@ const ArtworkPage = () => {
 
 function Item({ artwork }: { artwork: Artwork }) {
   return (
-    <div>
+    <div className="p-2 mx-1 mb-5">
       <div className="flex justify-center">
         <img
           src={artwork.image}


### PR DESCRIPTION
- Adds back padding that was reverted with: #1213
- Adds margin to items, to better space them out
- Aligns items to bottom, so title and artists are aligned in one row.

Alignment before: 
![image](https://user-images.githubusercontent.com/32012862/85953685-8ced6580-b972-11ea-8bfe-baf4d37da314.png)

After:
![image](https://user-images.githubusercontent.com/32012862/85953699-a68ead00-b972-11ea-9f1c-ebf27d53bd10.png)

