### PR TITLE
Add base91

### DIFF
--- a/database.json
+++ b/database.json
@@ -260,18 +260,18 @@
     "desc": "base64 strings from/to Uint8Arrays",
     "default_version": "master"
   },
-  "bb64": {
-    "type": "github",
-    "owner": "denjucks",
-    "repo": "bb64",
-    "desc": "Advanced method for encoding binary data as ASCII characters that's more efficient than base64 and base85",
-    "default_version": "master"
-  },
   "base91": {
     "type": "github",
     "owner": "oplik0",
     "repo": "base91-deno",
     "desc": "Ascii-based encoding more space efficient than base64 or base85",
+    "default_version": "master"
+  },
+  "bb64": {
+    "type": "github",
+    "owner": "denjucks",
+    "repo": "bb64",
+    "desc": "A better base64 encoder and decoder for Deno for easily encoding strings, Uint8Arrays, and files, including MIME types into encoding",
     "default_version": "master"
   },
   "bcrypt": {

--- a/database.json
+++ b/database.json
@@ -264,7 +264,14 @@
     "type": "github",
     "owner": "denjucks",
     "repo": "bb64",
-    "desc": "A better base64 encoder and decoder for Deno for easily encoding strings, Uint8Arrays, and files, including MIME types into encoding",
+    "desc": "Advanced method for encoding binary data as ASCII characters that's more efficient than base64 and base85",
+    "default_version": "master"
+  },
+  "base91": {
+    "type": "github",
+    "owner": "oplik0",
+    "repo": "base91-deno",
+    "desc": "Ascii-based encoding more space efficient than base64 or base85",
     "default_version": "master"
   },
   "bcrypt": {


### PR DESCRIPTION
Recommended to be added here instead of `std/encoding` (at least for now) by @ry here: https://github.com/denoland/deno/pull/6487

Implementation of [basE91](http://base91.sourceforge.net/) in Deno.
Base91 is (as far as I know) most common ascii-only encoding above base85, providing a more efficient - both space-wise and performance-wise - way to store binary data as text. Compared to base64, base91 string should be between 7.7% to 14.3% smaller.