### PR TITLE
Adds doa module to the third party database

### DIFF
--- a/database.json
+++ b/database.json
@@ -1650,6 +1650,13 @@
     "desc": "A module manager for Deno",
     "default_version": "master"
   },
+  "doa": {
+    "type": "github",
+    "owner": "johannlai",
+    "repo": "doa",
+    "desc": "A middleware framework for Deno's http serve.Transplanted from Koa.",
+    "default_version": "master"
+  },
   "docable": {
     "type": "github",
     "owner": "crookse",


### PR DESCRIPTION
Working on a project called doa, a middleware framework for Deno's http serve,  and would like to add it to the third party database, thanks team. 😄