### PR TITLE
Add random_primes to Third Party Modules

### DIFF
--- a/database.json
+++ b/database.json
@@ -3940,6 +3940,13 @@
     "desc": "deno random interval",
     "default_version": "master"
   },
+  "random_primes": {
+    "type": "github",
+    "owner": "jacob-ian",
+    "repo": "deno_random_primes",
+    "desc": "Generate random prime numbers by bit-length with Deno and the Miller-Rabin test.",
+    "default_version": "master"
+  },
   "ranking": {
     "type": "github",
     "owner": "yoshixmk",


### PR DESCRIPTION
A module to generate random prime numbers with a given bit length and desired number of primality tests.