### PR TITLE
feat: update superoak default branch to main

### DIFF
--- a/database.json
+++ b/database.json
@@ -4525,7 +4525,7 @@
     "owner": "asos-craigmorten",
     "repo": "superoak",
     "desc": "HTTP assertions for Oak made easy via superdeno.",
-    "default_version": "master"
+    "default_version": "main"
   },
   "supports_color": {
     "type": "github",


### PR DESCRIPTION
This PR updates the default branch in the `database.json` for the [SuperOak](https://github.com/asos-craigmorten/superoak) to now point to `main`.