### PR TITLE
Deprecate npm

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -197,14 +197,15 @@ const Registry = () => {
                 }.`}
               />
             )}
-            {findDatabaseEntry(name)?.type === "npm" && !name.startsWith("npm:") && (
-              <WarningMessage
-                title="NPM entries deprecation notice"
-                body={`NPM backed deno.land/x entries like ${name} are deprecated will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com${
-                  raw ? ` via the URL ${sourceURL}` : ""
-                }.`}
-              />
-            )}
+            {findDatabaseEntry(name)?.type === "npm" &&
+              !name.startsWith("npm:") && (
+                <WarningMessage
+                  title="NPM entries deprecation notice"
+                  body={`NPM backed deno.land/x entries like ${name} are deprecated will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com${
+                    raw ? ` via the URL ${sourceURL}` : ""
+                  }.`}
+                />
+              )}
             <Breadcrumbs
               name={name}
               version={version}

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -9,6 +9,7 @@ import {
   denoDocAvailableForURL,
   isReadme,
   findEntry,
+  entries,
 } from "../util/registry_utils";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -191,7 +192,15 @@ const Registry = () => {
             {name.startsWith("npm:") && (
               <WarningMessage
                 title="deno.land/x/npm:project redirect deprecation notice"
-                body={`The https://deno.land/x/npm:project style redirects are deprecated and will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com via the URL ${
+                body={`The https://deno.land/x/npm:project style redirects are deprecated and will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com${
+                  raw ? ` via the URL ${sourceURL}` : ""
+                }.`}
+              />
+            )}
+            {entries[name]?.type === "npm" && !name.startsWith("npm:") && (
+              <WarningMessage
+                title="NPM entries deprecation notice"
+                body={`NPM backed deno.land/x entries like ${name} are deprecated will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com${
                   raw ? ` via the URL ${sourceURL}` : ""
                 }.`}
               />

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -9,7 +9,7 @@ import {
   denoDocAvailableForURL,
   isReadme,
   findEntry,
-  entries,
+  findDatabaseEntry,
 } from "../util/registry_utils";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -197,7 +197,7 @@ const Registry = () => {
                 }.`}
               />
             )}
-            {entries[name]?.type === "npm" && !name.startsWith("npm:") && (
+            {findDatabaseEntry(name)?.type === "npm" && !name.startsWith("npm:") && (
               <WarningMessage
                 title="NPM entries deprecation notice"
                 body={`NPM backed deno.land/x entries like ${name} are deprecated will be removed on August 1st 2020. Instead of importing via deno.land you can import this module directly from unpkg.com${

--- a/util/registries.ts
+++ b/util/registries.ts
@@ -1,7 +1,6 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 export interface DatabaseEntry {
-  type: string;
   desc: string;
 }
 

--- a/util/registries.ts
+++ b/util/registries.ts
@@ -1,6 +1,7 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 export interface DatabaseEntry {
+  type: string;
   desc: string;
 }
 

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -7,7 +7,7 @@ import { URLEntry, URLDatabaseEntry } from "./registries/url";
 import { NPMEntry, NPMDatabaseEntry } from "./registries/npm";
 import { Entry, DatabaseEntry } from "./registries";
 
-function findDatabaseEntry(
+export function findDatabaseEntry(
   name: string
 ):
   | GithubDatabaseEntry

--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -1,7 +1,7 @@
 import {
   parseNameVersion,
   findEntry,
-  entries,
+  findDatabaseEntry,
 } from "../../util/registry_utils";
 
 export async function handleRegistryRequest(url: URL): Promise<Response> {
@@ -71,8 +71,8 @@ export function needsNPMDeprecationWarning(entry: Entry): boolean {
 }
 
 export function needsNPMTypeDeprecationWarning(entry: Entry): boolean {
-  const e = entries[entry.name];
-  return e && e.type === "npm";
+  const e = findDatabaseEntry(entry.name);
+  return e?.type === "npm";
 }
 
 export interface Entry {

--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -1,4 +1,8 @@
-import { parseNameVersion, findEntry } from "../../util/registry_utils";
+import {
+  parseNameVersion,
+  findEntry,
+  entries,
+} from "../../util/registry_utils";
 
 export async function handleRegistryRequest(url: URL): Promise<Response> {
   console.log("registry request", url.pathname);
@@ -27,6 +31,11 @@ export async function handleRegistryRequest(url: URL): Promise<Response> {
     response.headers.set(
       "X-Deno-Warning",
       `The https://deno.land/x/npm:project redirects are deprecated will be removed on August 1st 2020. Import ${entry.url} instead of ${url}`
+    );
+  } else if (needsNPMTypeDeprecationWarning(entry)) {
+    response.headers.set(
+      "X-Deno-Warning",
+      `NPM backed deno.land/x entries like ${entry.name} are deprecated will be removed on August 1st 2020. Import ${entry.url} instead of ${url}`
     );
   }
   const originContentType = response.headers.get("content-type");
@@ -59,6 +68,11 @@ export function needsGHDeprecationWarning(entry: Entry): boolean {
 
 export function needsNPMDeprecationWarning(entry: Entry): boolean {
   return entry.name.startsWith("npm:");
+}
+
+export function needsNPMTypeDeprecationWarning(entry: Entry): boolean {
+  const e = entries[entry.name];
+  return e && e.type === "npm";
 }
 
 export interface Entry {


### PR DESCRIPTION
For some background: we are rewriting the deno.land registry service and it will initially not have NPM or arbitrary URL support. This might be re-added later. Only three entries are npm based so it does not have a high priority at the moment.

- `unexpected`, added by @alexjeffburke
- ~~`value-schema`, added by @shimataro~~ (#1303)
- `libauth`, added by @bitjson 

These entries will be removed on September 1st 2020.