### PR TITLE
ci: merge ci job added for automatically close PR where database and …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,43 @@ jobs:
           environment: "staging"
           apiToken: ${{ secrets.cloudflareToken }}
           workingDirectory: worker
+  merge:
+    needs: [web, worker]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@v2
+        if: github.event_name == 'pull_request'
+        with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          let isDatabaseChanges = false, isArtworkChanges = false;
+          const repo = context.repo;
+          const regInp = ["artwork.json", ".png", ".jpeg", ".jpg", ".gif"];
+          const pull_issue_number = context.issue.number;
+          const options = await github.pulls.listFiles({
+            ...repo,
+            pull_number: pull_issue_number,
+          });
+          const files = (
+            (await github.paginate(options, (response) => response.data)) || []
+          )
+            .map((x) => x.filename)
+            .filter(Boolean);
+          if (
+            files.length === 1 &&
+            files.filter((f) => f.includes("database.json")).length === 1
+          ) {
+            isDatabaseChanges = true;
+          }
+          if (
+            files.filter((t) => regInp.map((re) => new RegExp(re, "i")).filter((re) => re.test(t)).length).length === 2
+          ) {
+            isArtworkChanges = true;
+          }
+          if (isDatabaseChanges || isArtworkChanges) {
+            await github.pulls.merge({
+              ...repo,
+              pull_number: pull_issue_number,
+            });
+          }


### PR DESCRIPTION
This PR is made for add new CI Job (`merge`) to automatically close PR where database and artwork changes there.

**Condition**
- **Database changes:**
   - If there is only one file changed and of it is `database.json` then PR will auto-merge.
-  **Artwork changes:**
   - If there are two file changed one is `artwork.json` and image file for the artwork changes. then PR will auto-merge.

The merge job is dependence on `web` and `worker` job. Once both job gets success then only this job will work. Also it will merge only on `pull_request` event.