### PR TITLE
Add http-status utility

### DIFF
--- a/database.json
+++ b/database.json
@@ -2635,6 +2635,13 @@
     "desc": "http-server is a tiny and zero-configuration HTTP server with useful features to serve static files with Deno",
     "default_version": "master"
   },
+   "http_status": {
+    "type": "github",
+    "owner": "brion-fuller",
+    "repo": "http-status",
+    "desc": "http-status is a simple HTTP status utility for deno",
+    "default_version": "master"
+  },
   "http_wrapper": {
     "type": "github",
     "owner": "lindsaykwardell",

--- a/database.json
+++ b/database.json
@@ -2635,7 +2635,7 @@
     "desc": "http-server is a tiny and zero-configuration HTTP server with useful features to serve static files with Deno",
     "default_version": "master"
   },
-   "http_status": {
+  "http_status": {
     "type": "github",
     "owner": "brion-fuller",
     "repo": "http-status",


### PR DESCRIPTION
Simple HTTP status utility for deno.  It's a simple mapping that exports HTTP Status codes that are assigned a number.  Message is added to the number class to return the status code text.