### PR TITLE
Add GitHub link to error message

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -327,7 +327,11 @@ function WarningMessage(props: { title: string; body: string }) {
   );
 }
 
-function ErrorMessage(props: { title: string; body: string; repositoryURL?: string }) {
+function ErrorMessage(props: {
+  title: string;
+  body: string;
+  repositoryURL?: string;
+}) {
   return (
     <div className="rounded-md bg-red-50 border border-red-200 p-4 my-4">
       <div className="flex">
@@ -350,7 +354,15 @@ function ErrorMessage(props: { title: string; body: string; repositoryURL?: stri
           </h3>
           <div className="mt-2 text-sm leading-5 text-red-700">
             {props.body}
-            {props.repositoryURL && <>You may <a className="link" href={props.repositoryURL}>view it on GitHub</a>.</>}
+            {props.repositoryURL && (
+              <>
+                You may{" "}
+                <a className="link" href={props.repositoryURL}>
+                  view it on GitHub
+                </a>
+                .
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -356,7 +356,8 @@ function ErrorMessage(props: {
             {props.body}
             {props.repositoryURL && (
               <>
-                {" "}You may{" "}
+                {" "}
+                You may{" "}
                 <a className="link" href={props.repositoryURL}>
                   view it on GitHub
                 </a>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -255,6 +255,7 @@ const Registry = () => {
               <ErrorMessage
                 title="Failed to get directory listing"
                 body={dirEntries.message}
+                repositoryURL={repositoryURL}
               />
             ) : dirEntries !== undefined && dirEntries !== null ? (
               <DirectoryListing
@@ -326,7 +327,7 @@ function WarningMessage(props: { title: string; body: string }) {
   );
 }
 
-function ErrorMessage(props: { title: string; body: string }) {
+function ErrorMessage(props: { title: string; body: string; repositoryURL?: string }) {
   return (
     <div className="rounded-md bg-red-50 border border-red-200 p-4 my-4">
       <div className="flex">
@@ -349,6 +350,7 @@ function ErrorMessage(props: { title: string; body: string }) {
           </h3>
           <div className="mt-2 text-sm leading-5 text-red-700">
             {props.body}
+            {props.repositoryURL && <>You may <a className="link" href={props.repositoryURL}>view it on GitHub</a>.</>}
           </div>
         </div>
       </div>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -356,7 +356,7 @@ function ErrorMessage(props: {
             {props.body}
             {props.repositoryURL && (
               <>
-                You may{" "}
+                {" "}You may{" "}
                 <a className="link" href={props.repositoryURL}>
                   view it on GitHub
                 </a>


### PR DESCRIPTION
Add a handy link to GitHub if there is an error.

![image](https://user-images.githubusercontent.com/44045911/88629234-90931a00-d0e1-11ea-9bb7-7e82896129bb.png)


Fix #946