### PR TITLE
Fix package not found on deno.land/x

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -103,7 +103,7 @@ const Registry = () => {
       .catch((e) => {
         console.error("Failed to fetch dir entry:", e);
         setDirEntries(new RegistryError(e?.message ?? e.toString()));
-      });
+      }) ?? setDirEntries(null);
   }, [entry, path, version]);
 
   // Fetch versions


### PR DESCRIPTION
The website now correctly display not found error for packages on `deno.land/x`.

![image](https://user-images.githubusercontent.com/44045911/88634009-62650880-d0e8-11ea-9014-0295345b7620.png)

Fix #579