### PR TITLE
feat: add yargs-parser to database.json

### DIFF
--- a/database.json
+++ b/database.json
@@ -5551,6 +5551,13 @@
     "desc": "WebAssembly module to parse YAML",
     "default_version": "master"
   },
+  "yargs_parser": {
+    "type": "github",
+    "owner": "yargs",
+    "repo": "yargs-parser",
+    "desc": "💪the mighty option parser used by yargs",
+    "default_version": "deno"
+  },
   "yeswehack": {
     "type": "github",
     "owner": "tchenu",


### PR DESCRIPTION
I deno compatible version of yargs-parser is now being published to yargs/yargs-parser@deno.

Refs: https://github.com/yargs/yargs-parser/pull/295