### PR TITLE
Added subdirectory input validation

### DIFF
--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -230,7 +230,8 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
                             <p className="text-red-400 mb-2">
                               The provided subdirectory is not valid. It must
                               end with a <InlineCode>/</InlineCode>, but may not
-                              start with one. (e.g. <InlineCode>src/</InlineCode>)
+                              start with one. (e.g.{" "}
+                              <InlineCode>src/</InlineCode>)
                             </p>
                           ) : null}
                           <span className="text-gray-500">

--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -5,7 +5,7 @@ import InlineCode from "./InlineCode";
 import { getVersionList } from "../util/registry_utils";
 
 const VALID_NAME = /^[a-z0-9_]{3,40}$/,
-  VALID_SUBDIRECTORY = /(.*\/$)/;
+  VALID_SUBDIRECTORY = /^([^(\/)])(.*\/$)/;
 
 function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
   // Stage of the instructions
@@ -228,8 +228,8 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
                           />
                           {isSubdirectoryValid === false ? (
                             <p className="text-red-400 mb-2">
-                              Provided sub directory is not valid as it does not
-                              end with a /
+                              Provided sub directory is not valid it should not
+                              start with a / and should end with a /
                             </p>
                           ) : null}
                           <span className="text-gray-500">

--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -4,7 +4,8 @@ import Transition from "./Transition";
 import InlineCode from "./InlineCode";
 import { getVersionList } from "../util/registry_utils";
 
-const VALID_NAME = /^[a-z0-9_]{3,40}$/;
+const VALID_NAME = /^[a-z0-9_]{3,40}$/,
+  VALID_SUBDIRECTORY = /(.*\/$)/;
 
 function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
   // Stage of the instructions
@@ -27,6 +28,12 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
         .then((e) => !e)
         .catch(() => false),
     { refreshInterval: 2000 }
+  );
+
+  // Subdirectory of the module name
+  const isSubdirectoryValid = useMemo(
+    () => !subdirectory || VALID_SUBDIRECTORY.test(subdirectory),
+    [subdirectory]
   );
 
   // No page scroll when sidebar is open
@@ -207,12 +214,24 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
                           </label>
                           <input
                             id="subdirectory"
-                            className={`block w-full px-4 py-2 my-1 leading-normal bg-white border border-gray-200 rounded-lg outline-none shadow hover:shadow-sm focus:shadow-sm appearance-none focus:border-gray-300 hover:border-gray-300 mt-1`}
+                            className={`block w-full px-4 py-2 my-1 leading-normal bg-white border border-gray-200 rounded-lg outline-none shadow hover:shadow-sm focus:shadow-sm appearance-none focus:border-gray-300 hover:border-gray-300 mt-1 ${
+                              isSubdirectoryValid === true
+                                ? "border-green-300 hover:border-green-300 focus:border-green-300"
+                                : isSubdirectoryValid === false
+                                ? "border-red-300 hover:border-red-300 focus:border-red-300"
+                                : ""
+                            }`}
                             type="text"
                             placeholder="Subdirectory"
                             value={subdirectory}
                             onChange={(e) => setSubdirectory(e.target.value)}
                           />
+                          {isSubdirectoryValid === false ? (
+                            <p className="text-red-400 mb-2">
+                              Provided sub directory is not valid as it does not
+                              end with a /
+                            </p>
+                          ) : null}
                           <span className="text-gray-500">
                             Optional. A subdirectory in your repository that the
                             module to be published is located in.
@@ -221,7 +240,14 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
                         <span className="block w-full rounded-md shadow-sm mt-2">
                           <button
                             type="submit"
-                            className="w-full flex justify-center py-2 px-4 border border-gray-300 text-md font-medium rounded-md text-gray-700 bg-gray-100 hover:text-gray-500 hover:bg-gray-50 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition duration-150 ease-in-out"
+                            disabled={!isSubdirectoryValid ? true : undefined}
+                            className={`w-full flex justify-center py-2 px-4 border border-gray-300 text-md font-medium rounded-md 
+                              ${
+                                isSubdirectoryValid
+                                  ? "text-gray-700 bg-gray-100 hover:text-gray-500 hover:bg-gray-50"
+                                  : "text-gray-400 bg-gray-50 cursor-default"
+                              }  
+                            text-gray-700 bg-gray-100 hover:text-gray-500 hover:bg-gray-50 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition duration-150 ease-in-out`}
                             onClick={() => setStage(3)}
                           >
                             Next

--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -228,8 +228,9 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
                           />
                           {isSubdirectoryValid === false ? (
                             <p className="text-red-400 mb-2">
-                              Provided sub directory is not valid it should not
-                              start with a / and should end with a /
+                              The provided subdirectory is not valid. It must
+                              end with a <InlineCode>/</InlineCode>, but may not
+                              start with one. (e.g. <InlineCode>src/</InlineCode>)
                             </p>
                           ) : null}
                           <span className="text-gray-500">

--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -5,7 +5,7 @@ import InlineCode from "./InlineCode";
 import { getVersionList } from "../util/registry_utils";
 
 const VALID_NAME = /^[a-z0-9_]{3,40}$/,
-  VALID_SUBDIRECTORY = /^([^(\/)])(.*\/$)/;
+  VALID_SUBDIRECTORY = /^([^(/)])(.*\/$)/;
 
 function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
   // Stage of the instructions

--- a/components/RegistryInstructions.tsx
+++ b/components/RegistryInstructions.tsx
@@ -30,7 +30,7 @@ function RegistryInstructions(props: { isOpen: boolean; close: () => void }) {
     { refreshInterval: 2000 }
   );
 
-  // Subdirectory of the module name
+  // Validity of the subdirectory
   const isSubdirectoryValid = useMemo(
     () => !subdirectory || VALID_SUBDIRECTORY.test(subdirectory),
     [subdirectory]


### PR DESCRIPTION
Validate module subdirectory before getting `{"success":false,"info":"provided sub directory is not valid as it does not end with a /"}
` error on webhooks!
By the way with this implementation input likes '//' are valid. It just makes sure that either input does not provide or ends with '/' and I don't know if that's fine or not.