### PR TITLE
add InlineCode tag fot `deno info`, `deno fmt` in top page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,8 +56,8 @@ for await (const req of s) {
             <li>Supports TypeScript out of the box.</li>
             <li>Ships only a single executable file.</li>
             <li>
-              Has built-in utilities like a dependency inspector (deno info) and
-              a code formatter (deno fmt).
+              Has built-in utilities like a dependency inspector (<InlineCode>deno info</InlineCode>) and
+              a code formatter (<InlineCode>deno fmt</InlineCode>).
             </li>
             <li>
               Has a set of reviewed (audited) standard modules that are

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,8 +56,9 @@ for await (const req of s) {
             <li>Supports TypeScript out of the box.</li>
             <li>Ships only a single executable file.</li>
             <li>
-              Has built-in utilities like a dependency inspector (<InlineCode>deno info</InlineCode>) and
-              a code formatter (<InlineCode>deno fmt</InlineCode>).
+              Has built-in utilities like a dependency inspector (
+              <InlineCode>deno info</InlineCode>) and a code formatter (
+              <InlineCode>deno fmt</InlineCode>).
             </li>
             <li>
               Has a set of reviewed (audited) standard modules that are


### PR DESCRIPTION
On [top page's](https://deno.land/) deno highlight, there is 
> - Has built-in utilities like a dependency inspector (deno info) and a code formatter (deno fmt).

`deno info` and `deno fmt` are commands not just strings, so these should look like commands same as

>To make it easier to consume third party modules Deno provides some built in tooling like `deno info` and `deno doc`. deno.land also provides a web UI for viewing module documentation. It is available at [doc.deno.land](https://doc.deno.land/).

in Third Party Modules section in the same page