### PR TITLE
add link to scoop.sh

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -258,7 +258,12 @@ const InstallSection = () => {
   );
   const scoop = (
     <div key="scoop" className="my-4 text-gray-700">
-      <p className="mb-2">Scoop (Windows):</p>
+      <p className="mb-2">
+        <a href="https://scoop.sh/" className="link">
+          Scoop
+        </a>{" "}
+        (Windows):
+      </p>
       <CodeBlock language="bash" code={`scoop install deno`} />
     </div>
   );


### PR DESCRIPTION
On top page's installation section, there is
> Scoop (Windows):
> ```
> scoop install deno
> ```

it's better to change like this: 

[Scoop](https://scoop.sh/) (Windows):
```
scoop install deno
```

reference: [installation section in manual](https://deno.land/manual/getting_started/installation) 