### PR TITLE
[Manual] Align list items correctly

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -603,7 +603,7 @@ function ToC({
   return (
     <div className="pt-2 pb-8 h-0 flex-1 flex flex-col overflow-y-auto">
       <nav className="flex-1 px-4">
-        <ol className="pl-2 list-decimal list-inside font-semibold nested">
+        <ol className="list-decimal list-inside font-semibold nested">
           {tableOfContents &&
             Object.entries(tableOfContents).map(([slug, entry]) => {
               return (


### PR DESCRIPTION
Align the list items align with dropdown and logo. Was upsetting my design OCD 😆 

From:
<img width="272" alt="Screenshot 2020-08-13 at 10 34 51" src="https://user-images.githubusercontent.com/32820112/90119156-20c39700-dd51-11ea-8723-2d80236c7e62.png">

To:
<img width="274" alt="Screenshot 2020-08-13 at 10 38 09" src="https://user-images.githubusercontent.com/32820112/90119178-25884b00-dd51-11ea-9ed3-c423d8fbd8fc.png">