### PR TITLE
Refactor /x

### DIFF
--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -73,7 +73,9 @@ const ThirdPartyRegistryList = () => {
               id="query"
               className="block w-full px-4 py-2 leading-normal bg-white border border-gray-200 rounded-lg outline-none shadow hover:shadow-sm focus:shadow-sm appearance-none focus:border-gray-300 hover:border-gray-300 mt-1"
               type="text"
-              placeholder="Search"
+              placeholder={
+                !resp ? "Search" : `Search through ${resp.totalCount} modules`
+              }
               value={query}
               onChange={handleSearchInput}
             />
@@ -172,7 +174,7 @@ const ThirdPartyRegistryList = () => {
 
                       return (
                         <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
-                          <div className="flex-1 flex justify-between sm:hidden">
+                          <div className="flex-1 flex justify-between items-center sm:hidden">
                             <button
                               disabled={!hasPrevious}
                               onClick={() => setPage(page - 1)}
@@ -184,10 +186,13 @@ const ThirdPartyRegistryList = () => {
                             >
                               Previous
                             </button>
+                            <div className="text-base leading-6 text-gray-500">
+                              {page}/{pageCount}
+                            </div>
                             <button
                               disabled={!hasNext}
                               onClick={() => setPage(page + 1)}
-                              className={`relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md bg-white ${
+                              className={`relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md bg-white ml-4 ${
                                 hasNext
                                   ? "text-gray-700 hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700"
                                   : "text-gray-500 cursor-default"

--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -101,8 +101,122 @@ const ThirdPartyRegistryList = () => {
           </div>
           <div className="sm:max-w-screen-lg sm:mx-auto sm:px-6 md:px-8 pb-4 sm:pb-12">
             {resp === undefined ? (
-              <div className="p-4 text-center sm:text-left text-sm leading-5 font-medium text-gray-500 truncate">
-                Loading...
+              <div className="bg-white sm:shadow border border-gray-200 overflow-hidden sm:rounded-md mt-4">
+                <ul>
+                  {Array(20)
+                    .fill(null)
+                    .map((_, i) => (
+                      <li
+                        className={i !== 0 ? "border-t border-gray-200" : ""}
+                        key={i}
+                      >
+                        <div className="flex items-center px-4 sm:px-6 py-4">
+                          <div className="min-w-0 flex-1 flex items-center">
+                            <div className="min-w-0 flex-1">
+                              <div className="text-sm leading-5">
+                                <div className="h-3 bg-blue-100 w-1/3 sm:w-1/5 md:w-1/6"></div>
+                              </div>
+                              <div className="mt-1 flex items-center">
+                                <div className="h-3 bg-gray-100 w-5/6 sm:w-4/5 md:w-3/4"></div>
+                              </div>
+                            </div>
+                          </div>
+                          <div className="ml-6 mr-4 flex items-center">
+                            <div className="h-3 bg-gray-100 w-4"></div>
+                            <svg
+                              className="ml-1 text-gray-100 w-5 h-5"
+                              fill="currentColor"
+                              viewBox="0 0 20 20"
+                            >
+                              <title>star</title>
+                              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+                            </svg>
+                          </div>
+                          <div>
+                            <svg
+                              className="h-5 w-5 text-gray-100"
+                              fill="currentColor"
+                              viewBox="0 0 20 20"
+                            >
+                              <path
+                                fillRule="evenodd"
+                                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                </ul>
+                <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+                  <div className="flex-1 flex justify-between items-center sm:hidden">
+                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white">
+                      Previous
+                    </button>
+                    <div className="text-base leading-6 text-gray-500">
+                      <div className="h-3 w-4 bg-gray-100" />/
+                      <div className="h-3 w-4 bg-gray-100" />
+                    </div>
+                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white">
+                      Next
+                    </button>
+                  </div>
+                  <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                    <div className="h-3 w-32 bg-gray-100" />
+                    <div>
+                      <nav className="relative z-0 inline-flex shadow-sm text-gray-200 leading-5">
+                        <div className="-ml-px relative inline-flex items-center px-2 py-2 border border-gray-300 bg-white rounded-l-md">
+                          <svg
+                            className="h-5 w-5"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        </div>
+                        <div className="-ml-px relative items-center px-4 py-2 border border-gray-300 bg-white hidden md:inline-flex">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative items-center px-4 py-2 border border-gray-300 bg-white hidden md:inline-flex">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white">
+                          &nbsp;&nbsp;
+                        </div>
+                        <div className="-ml-px relative inline-flex items-center px-2 py-2 border border-gray-300 bg-white rounded-r-md">
+                          <svg
+                            className="h-5 w-5 text-gray-200"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        </div>
+                      </nav>
+                    </div>
+                  </div>
+                </div>
               </div>
             ) : resp === null ? (
               <div className="p-4 text-center sm:text-left text-sm leading-5 font-medium text-gray-500 truncate">
@@ -409,6 +523,24 @@ const ThirdPartyRegistryList = () => {
                 </div>
                 <div className="mt-12">
                   <dt className="text-lg leading-6 font-medium text-gray-900">
+                    Can I find functionality built-in to Deno here?
+                  </dt>
+                  <dd className="mt-2">
+                    <p className="text-base leading-6 text-gray-500">
+                      No, the built-in runtime is documented on{" "}
+                      <a className="link" href="https://doc.deno.land/">
+                        deno doc
+                      </a>{" "}
+                      and in the manual. See{" "}
+                      <Link href="/[identifier]" as="/std">
+                        <a className="link">/std</a>
+                      </Link>{" "}
+                      for the standard modules.
+                    </p>
+                  </dd>
+                </div>
+                <div className="mt-12">
+                  <dt className="text-lg leading-6 font-medium text-gray-900">
                     How do I add a module to deno.land/x?
                   </dt>
                   <dd className="mt-2">
@@ -448,24 +580,6 @@ const ThirdPartyRegistryList = () => {
                         be unsafe to not tag dependencies
                       </a>
                       . To get rid of the warning, explicitly specify a version.
-                    </p>
-                  </dd>
-                </div>
-                <div className="mt-12">
-                  <dt className="text-lg leading-6 font-medium text-gray-900">
-                    Can I find functionality built-in to Deno here?
-                  </dt>
-                  <dd className="mt-2">
-                    <p className="text-base leading-6 text-gray-500">
-                      No, the built-in runtime is documented on{" "}
-                      <a className="link" href="https://doc.deno.land/">
-                        deno doc
-                      </a>{" "}
-                      and in the manual. See{" "}
-                      <Link href="/[identifier]" as="/std">
-                        <a className="link">/std</a>
-                      </Link>{" "}
-                      for the standard modules.
                     </p>
                   </dd>
                 </div>

--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -66,6 +66,25 @@ const ThirdPartyRegistryList = () => {
         />
         <div>
           <div className="max-w-screen-lg mx-auto px-4 sm:px-6 md:px-8 mt-8">
+            <dt className="text-lg leading-6 font-medium text-gray-900">
+              What is deno.land/x?
+            </dt>
+            <dd className="mt-2">
+              <p className="text-base leading-6 text-gray-500">
+                <span className="font-semibold">deno.land/x</span> is a hosting
+                service for Deno scripts. It caches releases of open source
+                modules stored on GitHub and serves them at one easy to remember
+                domain.
+              </p>
+            </dd>
+
+            <div className="mt-2">
+              <a href="#info" className="link">
+                Learn more
+              </a>
+            </div>
+          </div>
+          <div className="max-w-screen-lg mx-auto px-4 sm:px-6 md:px-8 mt-8">
             <label htmlFor="query" className="font-medium sr-only">
               Search
             </label>
@@ -367,23 +386,13 @@ const ThirdPartyRegistryList = () => {
               </div>
             )}
           </div>
-          <div className="max-w-screen-xl mx-auto pt-4 pb-8 sm:pt-8 sm:pb-12 px-4 sm:px-6 lg:pt-12 lg:pb-16 lg:px-8">
+          <div
+            id="info"
+            className="max-w-screen-xl mx-auto pt-4 pb-8 sm:pt-8 sm:pb-12 px-4 sm:px-6 lg:pt-12 lg:pb-16 lg:px-8"
+          >
             <dl className="md:grid md:grid-cols-2 md:gap-8">
               <div>
                 <div>
-                  <dt className="text-lg leading-6 font-medium text-gray-900">
-                    What is deno.land/x?
-                  </dt>
-                  <dd className="mt-2">
-                    <p className="text-base leading-6 text-gray-500">
-                      <span className="font-semibold">deno.land/x</span> is a
-                      hosting service for Deno scripts. It caches releases of
-                      open source modules stored on GitHub and serves them at
-                      one easy to remember domain.
-                    </p>
-                  </dd>
-                </div>
-                <div className="mt-12">
                   <dt className="text-lg leading-6 font-medium text-gray-900">
                     How do I use modules on deno.land/x?
                   </dt>


### PR DESCRIPTION
Closes #1416

- Adds module count into search placeholder
- Adds current page and total page count to mobile paginator

+ @lucacasonato suggested to move the `What is deno.land/x` section to the top, with a call to action to the other sections at the bottom of the page.
   - Not sure, if this is exactly what was suggested
   - I think the top would be a bit cluttered, if `Learn more` was a button, so I used a simple link.
   - It navigates to the bottom of the page with `#info`.

Theres is a problem, where if you navigate to the site with `https://deno.land/x#info`, then it navigates to the correct place, but then the modules load, so it scrolls to the top of the page. Don't know what I should do with that.