### PR TITLE
Inline mobile paginator placeholder

### DIFF
--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -156,10 +156,10 @@ const ThirdPartyRegistryList = () => {
                       Previous
                     </button>
                     <div className="text-base leading-6 text-gray-500">
-                      <div className="h-3 w-4 bg-gray-100" />/
-                      <div className="h-3 w-4 bg-gray-100" />
+                      <div className="h-3 w-4 bg-gray-100 inline-block mr-1" />/
+                      <div className="h-3 w-4 bg-gray-100 inline-block ml-1" />
                     </div>
-                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white">
+                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white ml-4">
                       Next
                     </button>
                   </div>

--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -152,14 +152,14 @@ const ThirdPartyRegistryList = () => {
                 </ul>
                 <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
                   <div className="flex-1 flex justify-between items-center sm:hidden">
-                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white">
+                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 text-sm leading-5 font-medium rounded-md bg-white">
                       Previous
                     </button>
                     <div className="text-base leading-6 text-gray-500">
                       <div className="h-3 w-4 bg-gray-100 inline-block mr-1" />/
                       <div className="h-3 w-4 bg-gray-100 inline-block ml-1" />
                     </div>
-                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 rounded-md bg-white ml-4">
+                    <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-gray-100 text-sm leading-5 font-medium rounded-md bg-white ml-4">
                       Next
                     </button>
                   </div>


### PR DESCRIPTION
- Makes `/x` mobile paginator page placeholder inline
- Fixes `Previous`, `Next` buttons that changed size during loading

Before:
![image](https://user-images.githubusercontent.com/32012862/90641943-14987780-e232-11ea-8f78-6c1ff3c7bc84.png)

After:
![image](https://user-images.githubusercontent.com/32012862/90641967-1b26ef00-e232-11ea-8618-27de9790364c.png)
