### PR TITLE
Fix markdown code section horizontal scrollbar placement

### DIFF
--- a/components/markdown.css
+++ b/components/markdown.css
@@ -545,7 +545,7 @@ object {
 
 .markdown .highlight pre:not(.prism-code),
 .markdown pre:not(.prism-code) {
-  padding: 16px;
+  padding: 0 16px;
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
@@ -556,7 +556,7 @@ object {
 .markdown pre:not(.prism-code) code {
   display: inline;
   max-width: auto;
-  padding: 0;
+  padding: 16px 0;
   margin: 0;
   overflow: visible;
   line-height: inherit;


### PR DESCRIPTION
## Question
Looking at `.prism-code` sections on the main page, it doesnt have padding on the sides when scrolling:
![image](https://user-images.githubusercontent.com/32012862/90649449-0733bb00-e23b-11ea-9685-a4022578ec37.png)
Should the markdown code behave the same as `.prism-code` (and also Github)?

---

Horizontal scrollbar overlaps the last codeblock line. This PR fixes it.
There shouldn't be, and I couldn't see anything unrelated thing to change because of this.

Before:
![image](https://user-images.githubusercontent.com/32012862/90646819-eb7ae580-e237-11ea-9ae2-f1d0f1f29a47.png)
![image](https://user-images.githubusercontent.com/32012862/90646835-f03f9980-e237-11ea-89c0-e19d7a6624ae.png)

After: 
![image](https://user-images.githubusercontent.com/32012862/90647155-50364000-e238-11ea-9254-ebec68804a1f.png)
![image](https://user-images.githubusercontent.com/32012862/90647166-53313080-e238-11ea-9656-4eaa070bd9be.png)