### PR TITLE
 Scroll element into view on hash change (#1494)

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -43,7 +43,7 @@ export const RawCodeBlock = ({
   const codeDivClassNames =
     "text-gray-300 token-line text-right select-none text-xs";
   const onClick = (e: React.MouseEvent) => {
-    if (e.shiftKey) {
+    if (e.shiftKey) { 
       e.preventDefault();
       const { hash } = location;
       const target = (e.target as HTMLAnchorElement).hash;
@@ -52,12 +52,15 @@ export const RawCodeBlock = ({
         : target;
     }
   };
+
   if (enableLineRef) {
     useEffect(() => {
       const onHashChange = () => {
         setHashValue(location.hash);
+        const id = location.hash.substring(1);
+        document.getElementById(id)?.scrollIntoView()
       };
-      window.addEventListener("hashchange", onHashChange);
+      window.addEventListener("hashchange", onHashChange);  
       onHashChange();
       return () => {
         window.removeEventListener("hashchange", onHashChange);

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -43,7 +43,7 @@ export const RawCodeBlock = ({
   const codeDivClassNames =
     "text-gray-300 token-line text-right select-none text-xs";
   const onClick = (e: React.MouseEvent) => {
-    if (e.shiftKey) { 
+    if (e.shiftKey) {
       e.preventDefault();
       const { hash } = location;
       const target = (e.target as HTMLAnchorElement).hash;
@@ -58,9 +58,9 @@ export const RawCodeBlock = ({
       const onHashChange = () => {
         setHashValue(location.hash);
         const id = location.hash.substring(1);
-        document.getElementById(id)?.scrollIntoView()
+        document.getElementById(id)?.scrollIntoView();
       };
-      window.addEventListener("hashchange", onHashChange);  
+      window.addEventListener("hashchange", onHashChange);
       onHashChange();
       return () => {
         window.removeEventListener("hashchange", onHashChange);

--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -1,7 +1,7 @@
 import { parseNameVersion } from "../../util/registry_utils";
 
 const S3_BUCKET =
-  "http://deno-registry-prod-storagebucket-d7uq3yal946u.s3-website-us-east-1.amazonaws.com/";
+  "http://deno-registry2-prod-storagebucket-b3a31d16.s3-website-us-east-1.amazonaws.com/";
 
 export async function handleRegistryRequest(url: URL): Promise<Response> {
   console.log("registry request", url.pathname);


### PR DESCRIPTION
The issue was caused by a delay between page load and code view loading. originally it tries to go to the anchor tag that hadn't been generated.

Fixes #1494