### PR TITLE
Update Pika CDN to Skypack

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -180,7 +180,7 @@ for await (const req of s) {
             Deno can import modules from any location on the web, like GitHub, a
             personal webserver, or a CDN like{" "}
             <a href="https://www.skypack.dev" className="link">
-              skypack
+              Skypack
             </a>{" "}
             or{" "}
             <a href="https://jspm.io" className="link">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -179,8 +179,8 @@ for await (const req of s) {
           <p className="my-4 text-gray-700">
             Deno can import modules from any location on the web, like GitHub, a
             personal webserver, or a CDN like{" "}
-            <a href="https://pika.dev" className="link">
-              pika.dev
+            <a href="https://www.skypack.dev" className="link">
+              skypack
             </a>{" "}
             or{" "}
             <a href="https://jspm.io" className="link">


### PR DESCRIPTION
Skypack is the new CDN network from Pika, it replaces Pika CDN:

https://www.pika.dev/cdn

> Skypack is our new name for the Pika CDN. It's the same great CDN made faster, more stable, and with a bunch of new improvements that weren't available in the original. Visit www.skypack.dev to learn more and get started. 