### PR TITLE
fix(status): replace "View On Github" link

### DIFF
--- a/pages/status/[id].tsx
+++ b/pages/status/[id].tsx
@@ -82,7 +82,7 @@ const RestPage = () => {
                     <a
                       href={`https://github.com/${
                         data.options.repository
-                      }/blob/${data.options.ref}/${data.options.subdir ?? ""}`}
+                      }/tree/${data.options.ref}/${data.options.subdir ?? ""}`}
                       className="link"
                     >
                       View on GitHub


### PR DESCRIPTION
Original link pointed to: https://github.com/denosaurs/debug/blob/0.1.1/ resolving to a 404
Edited link now points to: https://github.com/denosaurs/debug/tree/0.1.1/ resolving correctly