### PR TITLE
feat: endpoints for generic import IntelliSense

### DIFF
--- a/public/.well-known/deno-import-intellisense.json
+++ b/public/.well-known/deno-import-intellisense.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "registries": [
+    {
+      "schema": "/x/:module([a-z0-9_]*)@:version?/:path*",
+      "variables": [
+        {
+          "key": "module",
+          "url": "https://api.deno.land/modules?simple=1"
+        },
+        {
+          "key": "version",
+          "url": "https://deno.land/_vsc1/modules/${module}"
+        },
+        {
+          "key": "path",
+          "url": "https://deno.land/_vsc1/modules/${module}/v/${{version}}"
+        }
+      ]
+    },
+    {
+      "schema": "/x/:module([a-z0-9_]*)/:path*",
+      "variables": [
+        {
+          "key": "module",
+          "url": "https://api.deno.land/modules?simple=1"
+        },
+        {
+          "key": "path",
+          "url": "https://deno.land/_vsc1/modules/${module}/v_latest"
+        }
+      ]
+    },
+    {
+      "schema": "/std@:version?/:path*",
+      "variables": [
+        {
+          "key": "version",
+          "url": "https://deno.land/_vsc1/modules/std"
+        },
+        {
+          "key": "path",
+          "url": "https://deno.land/_vsc1/modules/std/v/${{version}}"
+        }
+      ]
+    },
+    {
+      "schema": "/std/:path*",
+      "variables": [
+        {
+          "key": "path",
+          "url": "https://deno.land/_vsc1/modules/std/v_latest"
+        }
+      ]
+    }
+  ]
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -23,5 +23,8 @@
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"
+  },
+  "dependencies": {
+    "path-to-regexp": "^6.1.0"
   }
 }

--- a/worker/src/handler.ts
+++ b/worker/src/handler.ts
@@ -1,6 +1,7 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 import { handleRegistryRequest } from "./registry";
+import { handleVSCRequest } from "./vscode";
 
 const REMOTE_URL = "https://deno-website2.now.sh";
 
@@ -16,6 +17,10 @@ export async function handleRequest(request: Request) {
 
   if (url.pathname.startsWith("/typedoc")) {
     return Response.redirect("https://doc.deno.land/builtin/stable", 301);
+  }
+
+  if (url.pathname.startsWith("/_vsc")) {
+    return handleVSCRequest(url);
   }
 
   const isRegistryRequest =

--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -1,6 +1,6 @@
 import { parseNameVersion } from "../../util/registry_utils";
 
-const S3_BUCKET =
+export const S3_BUCKET =
   "http://deno-registry2-prod-storagebucket-b3a31d16.s3-website-us-east-1.amazonaws.com/";
 
 export async function handleRegistryRequest(url: URL): Promise<Response> {

--- a/worker/src/vscode.ts
+++ b/worker/src/vscode.ts
@@ -26,7 +26,10 @@ export async function handleVSCRequest(url: URL): Promise<Response> {
     const json = await resp.json();
     return new Response(JSON.stringify(json.versions), {
       status: 200,
-      headers: { "content-type": "application/json", "cache-control": "max-age=86400" },
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "max-age=86400",
+      },
     });
   }
 
@@ -74,6 +77,9 @@ async function getPaths(module: string, version: string): Promise<Response> {
     );
   return new Response(JSON.stringify(list), {
     status: 200,
-    headers: { "content-type": "application/json", "cache-control": "max-age=86400" },
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "max-age=86400",
+    },
   });
 }

--- a/worker/src/vscode.ts
+++ b/worker/src/vscode.ts
@@ -26,7 +26,7 @@ export async function handleVSCRequest(url: URL): Promise<Response> {
     const json = await resp.json();
     return new Response(JSON.stringify(json.versions), {
       status: 200,
-      headers: { "content-type": "json", "cache-control": "max-age=86400" },
+      headers: { "content-type": "application/json", "cache-control": "max-age=86400" },
     });
   }
 
@@ -62,7 +62,7 @@ async function getPaths(module: string, version: string): Promise<Response> {
   if (!resp.ok) return new Response("internal server error 2", { status: 500 });
   const json = await resp.json();
   const list = (json.directory_listing as Array<Record<string, string>>)
-    .filter((f) => f.type === "file")
+    .filter((f) => f.type === "file" && !f.path.includes("/_"))
     .map((f) => f.path.substring(1))
     .filter(
       (f) =>
@@ -74,6 +74,6 @@ async function getPaths(module: string, version: string): Promise<Response> {
     );
   return new Response(JSON.stringify(list), {
     status: 200,
-    headers: { "content-type": "json", "cache-control": "max-age=86400" },
+    headers: { "content-type": "application/json", "cache-control": "max-age=86400" },
   });
 }

--- a/worker/src/vscode.ts
+++ b/worker/src/vscode.ts
@@ -1,0 +1,79 @@
+import { match } from "path-to-regexp";
+import { S3_BUCKET } from "./registry";
+
+const VERSIONS = match("/_vsc1/modules/:module([a-z0-9_]*)");
+const PATHS = match("/_vsc1/modules/:module([a-z0-9_]*)/v/:version");
+const PATHS_LATEST = match("/_vsc1/modules/:module([a-z0-9_]*)/v_latest");
+
+/**
+ * /_vsc1/modules/:module returns a list of all versions for a module
+ *
+ * /_vsc1/modules/:module/v/:version returns a list of all code files for a version of module
+ *
+ * /_vsc1/modules/:module/v_latest returns a list of all code files for the latest version of module
+ */
+export async function handleVSCRequest(url: URL): Promise<Response> {
+  const pathname = url.pathname;
+
+  const versions = VERSIONS(pathname);
+  if (versions) {
+    const module = (versions.params as Record<string, string>)["module"];
+    const resp = await fetch(`${S3_BUCKET}${module}/meta/versions.json`);
+    if (resp.status === 403 || resp.status === 404)
+      return new Response("module not found", { status: 404 });
+    if (!resp.ok)
+      return new Response("internal server error 1", { status: 500 });
+    const json = await resp.json();
+    return new Response(JSON.stringify(json.versions), {
+      status: 200,
+      headers: { "content-type": "json", "cache-control": "max-age=86400" },
+    });
+  }
+
+  const paths = PATHS(pathname);
+  if (paths) {
+    const module = (paths.params as Record<string, string>)["module"];
+    const version = (paths.params as Record<string, string>)["version"];
+    return getPaths(module, version);
+  }
+
+  const pathsLatest = PATHS_LATEST(pathname);
+  if (pathsLatest) {
+    const module = (pathsLatest.params as Record<string, string>)["module"];
+    const resp = await fetch(`${S3_BUCKET}${module}/meta/versions.json`);
+    if (resp.status === 403 || resp.status === 404)
+      return new Response("module not found", { status: 404 });
+    if (!resp.ok)
+      return new Response("internal server error 3", { status: 500 });
+    const json = await resp.json();
+    if (!json.latest) return new Response("no latest version", { status: 404 });
+    return getPaths(module, json.latest);
+  }
+
+  return new Response("not found", { status: 404 });
+}
+
+async function getPaths(module: string, version: string): Promise<Response> {
+  const resp = await fetch(
+    `${S3_BUCKET}${module}/versions/${version}/meta/meta.json`
+  );
+  if (resp.status === 403 || resp.status === 404)
+    return new Response("module or version not found", { status: 404 });
+  if (!resp.ok) return new Response("internal server error 2", { status: 500 });
+  const json = await resp.json();
+  const list = (json.directory_listing as Array<Record<string, string>>)
+    .filter((f) => f.type === "file")
+    .map((f) => f.path.substring(1))
+    .filter(
+      (f) =>
+        f.endsWith(".jsx") ||
+        f.endsWith(".jsx") ||
+        f.endsWith(".ts") ||
+        f.endsWith(".tsx") ||
+        f.endsWith(".mjs")
+    );
+  return new Response(JSON.stringify(list), {
+    status: 200,
+    headers: { "content-type": "json", "cache-control": "max-age=86400" },
+  });
+}

--- a/worker/yarn.lock
+++ b/worker/yarn.lock
@@ -3889,6 +3889,11 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
 pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"


### PR DESCRIPTION
This will be used for the generic version of import IntelliSense in the VS Code extension.

This also adds the soon to be required `/.well-known/deno-import-intellisense.json` used for auto-discovery in the VS Code extension.