### PR TITLE
Fix encoded filenames on x

### DIFF
--- a/components/FileDisplay.tsx
+++ b/components/FileDisplay.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { RawCodeBlock } from "./CodeBlock";
 import Markdown from "./Markdown";
 import Link from "next/link";
-import { fileTypeFromURL, isReadme } from "../util/registry_utils";
+import {
+  fileTypeFromURL,
+  isReadme,
+  fileNameFromURL,
+} from "../util/registry_utils";
 import { useRouter } from "next/router";
 
 function FileDisplay(props: {
@@ -17,8 +21,7 @@ function FileDisplay(props: {
 }) {
   const { pathname } = useRouter();
   const filetype = fileTypeFromURL(props.sourceURL);
-  const segments = props.sourceURL.split("/");
-  const filename = segments[segments.length - 1];
+  const filename = fileNameFromURL(props.sourceURL);
 
   return (
     <div className="shadow-sm rounded-lg border border-gray-200 overflow-hidden bg-white">

--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -7,6 +7,7 @@ import {
   getVersionMeta,
   getVersionList,
   getModule,
+  fileNameFromURL,
 } from "./registry_utils";
 import "isomorphic-unfetch";
 
@@ -113,4 +114,9 @@ test("getModule", async () => {
     // eslint-disable-next-line @typescript-eslint/camelcase
     star_count: 2,
   });
+});
+
+test("fileNameFromURL", () => {
+  expect(fileNameFromURL("a/path/to/%5Bfile%5D.txt")).toBe("[file].txt");
+  expect(fileNameFromURL("a/path/to/file.tsx")).toBe("file.tsx");
 });

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -298,6 +298,11 @@ export function fileTypeFromURL(filename: string) {
   }
 }
 
+export function fileNameFromURL(url: string) {
+  const segments = decodeURI(url).split("/");
+  return segments[segments.length - 1];
+}
+
 export function denoDocAvailableForURL(filename: string) {
   const filetype = fileTypeFromURL(filename);
   switch (filetype) {


### PR DESCRIPTION
Closes #1529 

Encoded filenames were not displayed properly on file display on x, example:

![image](https://user-images.githubusercontent.com/21252014/94763358-6d564680-0380-11eb-9f12-57efca98229d.png)

Now the url is decoded and filenames are showing correctly

![image](https://user-images.githubusercontent.com/21252014/94763322-544d9580-0380-11eb-9b96-cd86c0859989.png)
