### PR TITLE
feat: copy markdown heading link to clipboard on click (#1524)

### DIFF
--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -138,12 +138,21 @@ function Markdown(props: MarkdownProps) {
       <div
         dangerouslySetInnerHTML={{ __html: raw }}
         className={`markdown py-8 px-4 ${props.className ?? ""}`}
+        onClick={handleClick}
       />
     );
   } catch (err) {
     console.log(err);
     return null;
   }
+}
+
+function handleClick(e: React.MouseEvent<HTMLElement>) {
+  const el = e.target as HTMLElement;
+  if (el.className !== "octicon-link") return;
+
+  const anchor = el.parentNode as HTMLAnchorElement;
+  navigator.clipboard.writeText(anchor.href);
 }
 
 function transformLinkUri(displayURL: string, baseURL: string) {


### PR DESCRIPTION
The cleanest way I found to use an `onClick` event for heading links inside `dangerouslySetInnerHTML` is to listen for events on the whole `div` and then inside the callback check if the `event.target` has a class `octicon-link`.

To write to clipboard I'm using `Clipboard API` - [here's the caniuse](https://caniuse.com/mdn-api_clipboard_writetext). Should I implement a fallback using `document.execCommand("copy")`? [relevant caniuse](https://caniuse.com/mdn-api_document_execcommand_copy)

Closes #1524