### PR TITLE
fix: set default cli version

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -44,7 +44,7 @@ function Manual() {
   const { version, path } = useMemo(() => {
     const [identifier, ...pathParts] = (query.rest as string[]) ?? [];
     const path = pathParts.length === 0 ? "" : `/${pathParts.join("/")}`;
-    const [_, version] = parseNameVersion(identifier ?? "");
+    const version = parseNameVersion(identifier ?? "")[1] ?? versionMeta.cli[0];
     return { version, path: path || "/introduction" };
   }, [query]);
 


### PR DESCRIPTION
When we don't provide specific version, $CLI_VERSION is undefined.
This cause some links to be invalid.

> https://deno.land/manual/runtime
> Additionally, a full list of the Web APIs which Deno implements is also available [in the repository](https://github.com/denoland/deno/blob/undefined/cli/rt/README.md).