### PR TITLE
[Fix] [404] Footer links were not clickable

### DIFF
--- a/components/app.css
+++ b/components/app.css
@@ -115,11 +115,11 @@ ul.tree li:last-child:before {
 
 .NotFoundPage .animation {
   width: 100%;
-  height: 100%;
+  height: 400px;
   position: absolute;
   left: 0;
   bottom: 0;
-  z-index: -1;
+  pointer-events: none;
 }
 
 .NotFoundPage .animation .land {
@@ -128,7 +128,7 @@ ul.tree li:last-child:before {
   height: 11.5rem;
   bottom: 0rem;
   left: 0;
-  z-index: 0;
+  pointer-events: initial;
 }
 
 .NotFoundPage .animation #ferris404 {
@@ -150,7 +150,7 @@ ul.tree li:last-child:before {
 
 @keyframes move {
   from {
-    left: -10%;
+    left: -200px;
   }
   to {
     left: 100%;


### PR DESCRIPTION
Sorry for another PR, one of my friends noticed that on the 404 page the elements on the footer were not reacting to mouse/touch events.

This fixes it.