### PR TITLE
Add esm.sh CDN

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -192,11 +192,11 @@ for await (const req of s) {
             ,{" "}
             <a href="https://jspm.io" className="link">
               jspm.io
-            </a>{" "}
+            </a>
             ,{" "}
             <a href="https://www.jsdelivr.com/" className="link">
               jsDelivr
-            </a>
+            </a>{" "}
             or{" "}
             <a href="https://esm.sh/" className="link">
               esm.sh

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -193,9 +193,13 @@ for await (const req of s) {
             <a href="https://jspm.io" className="link">
               jspm.io
             </a>{" "}
-            or{" "}
+            ,{" "}
             <a href="https://www.jsdelivr.com/" className="link">
               jsDelivr
+            </a>
+            or{" "}
+            <a href="https://esm.sh/" className="link">
+              esm.sh
             </a>
             .
           </p>


### PR DESCRIPTION
pull request again, since [esm.sh](https://esm.sh) has better Deno compatibility:
- `X-Typescript-Types` header provided
- nodejs internal modules(fs,readling,etc) polyfill

```javascript
import postcss from 'https://esm.sh/postcss'
import autoprefixer from 'https://esm.sh/autoprefixer'

const css = (await postcss([ autoprefixer]).process(`
    backdrop-filter: blur(5px);
    user-select: none;
`).async()).content
```