### PR TITLE
Fix header on news page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,7 +14,7 @@ function Header({
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="relative py-6">
+    <div className="relative py-6 z-10">
       <nav
         className={`mx-auto flex items-center justify-between px-4 sm:px-6 md:px-8 ${
           widerContent ? "max-w-screen-xl" : "max-w-screen-lg lg:p-0"


### PR DESCRIPTION
This PR fixes #1609 by adding a z-index to the header component.

#### Before:
<img width="1920" alt="before" src="https://user-images.githubusercontent.com/35741000/102356482-8cdb3380-3fad-11eb-9632-00eed09e0f10.png">

#### After:
<img width="1920" alt="after" src="https://user-images.githubusercontent.com/35741000/102357166-58b44280-3fae-11eb-9a20-27f3ef10824a.png">

