### PR TITLE
Hover transition effect on button

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,7 +44,7 @@ for await (const req of s) {
 
             <a
               href="https://github.com/denoland/deno/releases/latest"
-              className="rounded-full mt-4 px-8 py-2 bg-blue-500 text-white shadow-lg"
+              className="rounded-full mt-4 px-8 py-2 transition-colors duration-75 ease-in-out bg-blue-500 hover:bg-blue-400 text-white shadow-lg"
             >
               {versions.cli[0]}
             </a>


### PR DESCRIPTION
I noticed that every link on the index page is blue and gets a little lighter when hovering. Since I think the version button also falls into this category, it should have the same transition as the rest of the links to maintain the design line. 
With this PR the button gets the same hover transition as the rest of the links.