### PR TITLE
Update v1.6.md

### DIFF
--- a/public/posts/v1.6.md
+++ b/public/posts/v1.6.md
@@ -1,7 +1,7 @@
 Today we are releasing Deno 1.6.0. This release contains some major features,
 and many bug fixes. Here are some highlights:
 
-- [**Build self contained, standalone binaries**](#codedeno-compilecode-building-self-contained-standalone-binaries):
+- [**Build self contained, standalone binaries**](#codedeno-compilecode-self-contained-standalone-binaries):
   `deno compile` can build your Deno projects into completely standalone
   executables
 - [**Built-in Deno Language Server**](#built-in-deno-language-server): fully


### PR DESCRIPTION
Anchor to 'Build self contained, standalone binaries' was incorrect.