### PR TITLE
Fix in-page links in 1.7 release notes

### DIFF
--- a/public/posts/v1.7.md
+++ b/public/posts/v1.7.md
@@ -1,10 +1,10 @@
 Today we are releasing Deno 1.7.0. This release contains many new features, some
 stabilizations, and some great improvements to existing APIs and tooling.
 
-- [**Improvements to `deno compile`**](#): cross compilation, 60% reduction in
+- [**Improvements to `deno compile`**](#improvements-to-codedeno-compilecode): cross compilation, 60% reduction in
   output size, and more
-- [**Support for data URLs**](#): use `data:` URLs in imports and workers
-- [**New unstable `Deno.resolveDns` API**](#): query nameservers for DNS records
+- [**Support for data URLs**](#support-for-importing-data-urls): use `data:` URLs in imports and workers
+- [**New unstable `Deno.resolveDns` API**](#new-unstable-codedenoresolvednscode-api): query nameservers for DNS records
 
 If you already have Deno installed you can upgrade to 1.7 by running
 `deno upgrade`. If you are installing Deno for the first time, you can use one

--- a/public/posts/v1.7.md
+++ b/public/posts/v1.7.md
@@ -1,10 +1,12 @@
 Today we are releasing Deno 1.7.0. This release contains many new features, some
 stabilizations, and some great improvements to existing APIs and tooling.
 
-- [**Improvements to `deno compile`**](#improvements-to-codedeno-compilecode): cross compilation, 60% reduction in
-  output size, and more
-- [**Support for data URLs**](#support-for-importing-data-urls): use `data:` URLs in imports and workers
-- [**New unstable `Deno.resolveDns` API**](#new-unstable-codedenoresolvednscode-api): query nameservers for DNS records
+- [**Improvements to `deno compile`**](#improvements-to-codedeno-compilecode):
+  cross compilation, 60% reduction in output size, and more
+- [**Support for data URLs**](#support-for-importing-data-urls): use `data:`
+  URLs in imports and workers
+- [**New unstable `Deno.resolveDns` API**](#new-unstable-codedenoresolvednscode-api):
+  query nameservers for DNS records
 
 If you already have Deno installed you can upgrade to 1.7 by running
 `deno upgrade`. If you are installing Deno for the first time, you can use one


### PR DESCRIPTION
Nothing happens currently if one clicks these links. Fixes it so that people can jump within the page.