### PR TITLE
Add news in header and menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,6 +68,11 @@ function Header({
               Manual
             </a>
           </Link>
+          <Link href="/posts">
+            <a className="ml-10 font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
+              News
+            </a>
+          </Link>
           <a
             href="https://doc.deno.land/builtin/stable"
             className="ml-10 font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out"
@@ -169,6 +174,11 @@ function Header({
                 <Link href="/manual">
                   <a className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">
                     Manual
+                  </a>
+                </Link>
+                <Link href="/posts">
+                  <a className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">
+                    News
                   </a>
                 </Link>
                 <a


### PR DESCRIPTION
The news link is now only in the footer, and it feels so hidden. This PR adds the links to news in the header and the global menu.