### PR TITLE
fix: header has wider content on third party modules site

### DIFF
--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -74,7 +74,7 @@ function ThirdPartyRegistryList(): React.ReactElement {
       </Head>
       <CookieBanner />
       <div className="bg-gray">
-        <Header subtitle="Third Party Modules" />
+        <Header subtitle="Third Party Modules" widerContent={true} />
         <RegistryInstructions
           isOpen={overlayOpen}
           close={() => setOverlayOpen(false)}


### PR DESCRIPTION
In the current version of the third party modules page, the navigation in the desktop view already has two-line links, because it is not wide enough. In this PR, the widerContent condition is set to true so that the links are no longer double-spaced.