### PR TITLE
fix: wider header on benchmark page

### DIFF
--- a/pages/benchmarks.tsx
+++ b/pages/benchmarks.tsx
@@ -96,7 +96,7 @@ function Benchmarks(): React.ReactElement {
       </Head>
       <CookieBanner />
       <div className="bg-gray-50 min-h-full">
-        <Header subtitle="Continuous Benchmarks" />
+        <Header subtitle="Continuous Benchmarks" widerContent={true} />
         <div className="mb-12">
           <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 mt-8 pb-8">
             <img src="/images/deno_logo_4.gif" className="mb-12 w-32 h-32" />


### PR DESCRIPTION
Aims the same as the previous pull request (compare #1657), only that the header in the bechmark page is made wider, as this page has the same visual bug.