### PR TITLE
feat: support alt extensions for markdown

### DIFF
--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -121,7 +121,7 @@ test("getModule", async () => {
 });
 
 test("fileTypeFromURL", () => {
-  const tests: [string, string | undefined][] = [
+  const tests: Array<[string, string | undefined]> = [
     ["main.ts", "typescript"],
     ["lib.js", "javascript"],
     ["Component.tsx", "tsx"],
@@ -161,7 +161,7 @@ test("fileNameFromURL", () => {
 });
 
 test("findRootReadme", () => {
-  const tests: [string, boolean][] = [
+  const tests: Array<[string, boolean]> = [
     ["/README", true],
     ["/README.md", true],
     ["/readme.markdown", true],
@@ -187,7 +187,7 @@ test("findRootReadme", () => {
 });
 
 test("isReadme", () => {
-  const tests: [string, boolean][] = [
+  const tests: Array<[string, boolean]> = [
     ["README", true],
     ["README.md", true],
     ["readme.markdown", true],

--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -177,11 +177,11 @@ test("findRootReadme", () => {
   ];
 
   for (const [path, expectedToBeRootReadme] of tests) {
-    const rootReadme = findRootReadme([{ path, type: "file", size: 100 }])
+    const rootReadme = findRootReadme([{ path, type: "file", size: 100 }]);
     if (expectedToBeRootReadme) {
-      expect(rootReadme).not.toBe(undefined)
+      expect(rootReadme).not.toBe(undefined);
     } else {
-      expect(rootReadme).toBe(undefined)
+      expect(rootReadme).toBe(undefined);
     }
   }
 });
@@ -197,9 +197,9 @@ test("isReadme", () => {
     ["README.mkd", true],
     ["README.mkdown", false],
     ["README.markdn", false],
-    ["READTHIS.md", false]
-  ]
+    ["READTHIS.md", false],
+  ];
   for (const [path, expectedToBeReadme] of tests) {
-    expect(isReadme(path)).toBe(expectedToBeReadme)
+    expect(isReadme(path)).toBe(expectedToBeReadme);
   }
 });

--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -10,6 +10,9 @@ import {
   getVersionList,
   getModule,
   fileNameFromURL,
+  findRootReadme,
+  isReadme,
+  fileTypeFromURL,
 } from "./registry_utils";
 import "isomorphic-unfetch";
 
@@ -117,7 +120,86 @@ test("getModule", async () => {
   });
 });
 
+test("fileTypeFromURL", () => {
+  const tests: [string, string | undefined][] = [
+    ["main.ts", "typescript"],
+    ["lib.js", "javascript"],
+    ["Component.tsx", "tsx"],
+    ["Component.jsx", "jsx"],
+    ["data.json", "json"],
+    ["Cargo.toml", "toml"],
+    ["Cargo.lock", "toml"],
+    ["mod.rs", "rust"],
+    ["main.py", "python"],
+    ["lib.wasm", "wasm"],
+    ["Makefile", "makefile"],
+    ["Dockerfile", "dockerfile"],
+    ["build.Dockerfile", "dockerfile"],
+    ["config.yml", "yaml"],
+    ["config.yaml", "yaml"],
+    ["index.html", "html"],
+    ["index.htm", "html"],
+    ["readme.md", "markdown"],
+    ["readme.markdown", "markdown"],
+    ["readme.mdown", "markdown"],
+    ["readme.mkdn", "markdown"],
+    ["readme.mdwn", "markdown"],
+    ["readme.mkd", "markdown"],
+    ["image.png", "image"],
+    ["image.jpg", "image"],
+    ["image.jpeg", "image"],
+    ["file.unknown", undefined],
+  ];
+  for (const [name, expectedType] of tests) {
+    expect(fileTypeFromURL(name)).toBe(expectedType);
+  }
+});
+
 test("fileNameFromURL", () => {
   expect(fileNameFromURL("a/path/to/%5Bfile%5D.txt")).toBe("[file].txt");
   expect(fileNameFromURL("a/path/to/file.tsx")).toBe("file.tsx");
+});
+
+test("findRootReadme", () => {
+  const tests: [string, boolean][] = [
+    ["/README", true],
+    ["/README.md", true],
+    ["/readme.markdown", true],
+    ["/README.mdown", true],
+    ["/readme.mkdn", true],
+    ["/readme.mdwn", true],
+    ["/README.mkd", true],
+    ["/README.mkdown", false],
+    ["/README.markdn", false],
+    ["/READTHIS.md", false],
+    ["/docs/README.md", true],
+    ["/.github/README.md", true],
+  ];
+
+  for (const [path, expectedToBeRootReadme] of tests) {
+    const rootReadme = findRootReadme([{ path, type: "file", size: 100 }])
+    if (expectedToBeRootReadme) {
+      expect(rootReadme).not.toBe(undefined)
+    } else {
+      expect(rootReadme).toBe(undefined)
+    }
+  }
+});
+
+test("isReadme", () => {
+  const tests: [string, boolean][] = [
+    ["README", true],
+    ["README.md", true],
+    ["readme.markdown", true],
+    ["README.mdown", true],
+    ["readme.mkdn", true],
+    ["readme.mdwn", true],
+    ["README.mkd", true],
+    ["README.mkdown", false],
+    ["README.markdn", false],
+    ["READTHIS.md", false]
+  ]
+  for (const [path, expectedToBeReadme] of tests) {
+    expect(isReadme(path)).toBe(expectedToBeReadme)
+  }
 });

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -285,13 +285,13 @@ export function fileTypeFromURL(filename: string): string | undefined {
     return "wasm";
   } else if (f.toLocaleLowerCase().endsWith("makefile")) {
     return "makefile";
-  } else if (f.endsWith(".dockerfile") || f.endsWith("Dockerfile")) {
+  } else if (f.endsWith(".dockerfile") || f.endsWith("dockerfile")) {
     return "dockerfile";
   } else if (f.endsWith(".yml") || f.endsWith(".yaml")) {
     return "yaml";
   } else if (f.endsWith(".htm") || f.endsWith(".html")) {
     return "html";
-  } else if (f.endsWith(".md")) {
+  } else if (f.endsWith(".md") || f.endsWith(".markdown") || f.endsWith(".mdown") || f.endsWith(".mkdn") || f.endsWith(".mdwn") || f.endsWith(".mkd")) {
     return "markdown";
   } else if (f.endsWith(".png") || f.endsWith(".jpg") || f.endsWith(".jpeg")) {
     return "image";
@@ -321,20 +321,8 @@ export function findRootReadme(
 ): DirEntry | undefined {
   const listing =
     directoryListing?.find(
-      (d) =>
-        d.path.toLowerCase() === "/readme.md" ||
-        d.path.toLowerCase() === "/readme"
-    ) ??
-    directoryListing?.find(
-      (d) =>
-        d.path.toLowerCase() === "/docs/readme.md" ||
-        d.path.toLowerCase() === "/docs/readme"
-    ) ??
-    directoryListing?.find(
-      (d) =>
-        d.path.toLowerCase() === "/.github/readme.md" ||
-        d.path.toLowerCase() === "/.github/readme"
-    );
+      (d) => /^\/(docs\/|\.github\/)?readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(d.path)
+    )
   return listing
     ? {
         name: listing.path.substring(1),
@@ -345,10 +333,7 @@ export function findRootReadme(
 }
 
 export function isReadme(filename: string): boolean {
-  return (
-    filename.toLowerCase() === "readme.md" ||
-    filename.toLowerCase() === "readme"
-  );
+  return /^readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(filename)
 }
 
 export type Dep = { name: string; children: Dep[] };

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -291,7 +291,14 @@ export function fileTypeFromURL(filename: string): string | undefined {
     return "yaml";
   } else if (f.endsWith(".htm") || f.endsWith(".html")) {
     return "html";
-  } else if (f.endsWith(".md") || f.endsWith(".markdown") || f.endsWith(".mdown") || f.endsWith(".mkdn") || f.endsWith(".mdwn") || f.endsWith(".mkd")) {
+  } else if (
+    f.endsWith(".md") ||
+    f.endsWith(".markdown") ||
+    f.endsWith(".mdown") ||
+    f.endsWith(".mkdn") ||
+    f.endsWith(".mdwn") ||
+    f.endsWith(".mkd")
+  ) {
     return "markdown";
   } else if (f.endsWith(".png") || f.endsWith(".jpg") || f.endsWith(".jpeg")) {
     return "image";
@@ -319,10 +326,11 @@ export function denoDocAvailableForURL(filename: string): boolean {
 export function findRootReadme(
   directoryListing: DirListing[] | undefined
 ): DirEntry | undefined {
-  const listing =
-    directoryListing?.find(
-      (d) => /^\/(docs\/|\.github\/)?readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(d.path)
+  const listing = directoryListing?.find((d) =>
+    /^\/(docs\/|\.github\/)?readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(
+      d.path
     )
+  );
   return listing
     ? {
         name: listing.path.substring(1),
@@ -333,7 +341,9 @@ export function findRootReadme(
 }
 
 export function isReadme(filename: string): boolean {
-  return /^readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(filename)
+  return /^readme(\.markdown|\.mdown|\.mkdn|\.mdwn|\.mkd|\.md)?$/i.test(
+    filename
+  );
 }
 
 export type Dep = { name: string; children: Dep[] };


### PR DESCRIPTION
This PR supports alternative extensions for markdown files. I also added test cases of utility functions of registry.

closes https://github.com/denoland/deno_registry2/issues/206

GitHub seems supporting these extensions as alternative to .md
- https://github.com/browserify/browserify
- https://github.com/kt3k/deno_license_checker