### PR TITLE
fix: Force redirect from /x/std to /std

### DIFF
--- a/pages/x/[...rest].tsx
+++ b/pages/x/[...rest].tsx
@@ -1,10 +1,15 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import React from "react";
-
+import React, { useEffect } from "react";
+import {useRouter} from "next/router"
 import Registry from "../../components/Registry";
 
 function RegistryPage(): React.ReactElement {
+  const router = useRouter();
+  if (router.asPath.startsWith("/x/std")) {
+    router.replace("/std");
+  }
+
   return <Registry />;
 }
 


### PR DESCRIPTION
this pull request solves the need for issue #1520 to force the redirect from /x/std to /std