### PR TITLE
Fix typos in 1.8 post

### DIFF
--- a/public/posts/v1.8.md
+++ b/public/posts/v1.8.md
@@ -1,7 +1,7 @@
 Today we are releasing Deno 1.8.0. This release contains a massive amount of new
 features and stabilizations:
 
-- [**Exprimental support for WebGPU API**](#experimental-support-for-the-webgpu-api):
+- [**Experimental support for WebGPU API**](#experimental-support-for-the-webgpu-api):
   paving a path towards out-of-the-box GPU accelerated machine learning in Deno
 - [**Built-in internationalization APIs enabled**](#icu-support): all JS `Intl`
   APIs are available out of the box
@@ -38,7 +38,7 @@ choco install deno
 ## Experimental support for the WebGPU API
 
 The WebGPU API gives developers a low level, high performance, cross
-architechture way to program GPU hardware from JavaScript. It is the effective
+architecture way to program GPU hardware from JavaScript. It is the effective
 successor to WebGL on the Web. The spec has not yet been finalized, but support
 is currently being added to Firefox, Chromium, and Safari; and now also in Deno.
 
@@ -233,8 +233,8 @@ that are used when fetching modules for the first time.
 To do this the Deno CLI will look for an environment variable named
 `DENO_AUTH_TOKENS` to determine what authentication tokens it should consider
 using when requesting remote modules. The value of the environment variable is
-in the format of a n number of tokens deliminated by a semi-colon (`;`) where
-each token is in the format of `{token}@{hostname[:port]}`.
+in the format of a n number of tokens delimited by a semi-colon (`;`) where each
+token is in the format of `{token}@{hostname[:port]}`.
 
 For example a single token for would look something like this:
 
@@ -369,10 +369,10 @@ resource id of the opened file (or an error).
 
 More than two years ago, on Oct 11, 2018 we added a way for you to view metrics
 for all of the ops between Rust and JS: `Deno.metrics`. This API currently
-exposes the count of started, and completed sychronous and asynchronous ops, and
-the amount of data that has been sent over the ops interface. So far this has
-been limited to combined data for all of the different ops. There was no way to
-figure out _which_ ops were invoked how many times, only all ops in general.
+exposes the count of started, and completed synchronous and asynchronous ops,
+and the amount of data that has been sent over the ops interface. So far this
+has been limited to combined data for all of the different ops. There was no way
+to figure out _which_ ops were invoked how many times, only all ops in general.
 
 When running with `--unstable`, this release adds a new field to `Deno.metrics`
 called `ops`. This field contains per op information about how often the API was


### PR DESCRIPTION
Spotted a few minor typos in the post, suggested fixes.

`deliminated` might be ok...  but it seems unusual. I am used to `delimited`.