### PR TITLE
Fix typos

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -29,7 +29,6 @@ export interface CodeBlockProps {
     | "toml"
     | "wasm"
     | "makefile"
-    | "powershell"
     | "dockerfile";
 }
 

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -29,6 +29,7 @@ export interface CodeBlockProps {
     | "toml"
     | "wasm"
     | "makefile"
+    | "powershell"
     | "dockerfile";
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -260,7 +260,7 @@ const InstallSection = () => {
     <div key="powershell" className="my-4 text-gray-700">
       <p className="mb-2">PowerShell (Windows):</p>
       <CodeBlock
-        language="powershell"
+        language="bash"
         code={`iwr https://deno.land/x/install/install.ps1 -useb | iex`}
       />
     </div>
@@ -273,7 +273,7 @@ const InstallSection = () => {
         </a>{" "}
         (Windows):
       </p>
-      <CodeBlock language="powershell" code={`choco install deno`} />
+      <CodeBlock language="bash" code={`choco install deno`} />
     </div>
   );
   const scoop = (
@@ -284,7 +284,7 @@ const InstallSection = () => {
         </a>{" "}
         (Windows):
       </p>
-      <CodeBlock language="powershell" code={`scoop install deno`} />
+      <CodeBlock language="bash" code={`scoop install deno`} />
     </div>
   );
   const cargo = (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -260,7 +260,7 @@ const InstallSection = () => {
     <div key="powershell" className="my-4 text-gray-700">
       <p className="mb-2">PowerShell (Windows):</p>
       <CodeBlock
-        language="bash"
+        language="powershell"
         code={`iwr https://deno.land/x/install/install.ps1 -useb | iex`}
       />
     </div>
@@ -273,7 +273,7 @@ const InstallSection = () => {
         </a>{" "}
         (Windows):
       </p>
-      <CodeBlock language="bash" code={`choco install deno`} />
+      <CodeBlock language="powershell" code={`choco install deno`} />
     </div>
   );
   const scoop = (
@@ -284,7 +284,7 @@ const InstallSection = () => {
         </a>{" "}
         (Windows):
       </p>
-      <CodeBlock language="bash" code={`scoop install deno`} />
+      <CodeBlock language="powershell" code={`scoop install deno`} />
     </div>
   );
   const cargo = (
@@ -293,7 +293,7 @@ const InstallSection = () => {
         Build and install from source using{" "}
         <a href="https://crates.io/crates/deno" className="link">
           Cargo
-        </a>
+        </a>:
       </p>
       <CodeBlock language="bash" code={`cargo install deno --locked`} />
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -293,7 +293,8 @@ const InstallSection = () => {
         Build and install from source using{" "}
         <a href="https://crates.io/crates/deno" className="link">
           Cargo
-        </a>:
+        </a>
+        :
       </p>
       <CodeBlock language="bash" code={`cargo install deno --locked`} />
     </div>

--- a/public/posts/v1.8.md
+++ b/public/posts/v1.8.md
@@ -223,7 +223,7 @@ For more examples and a detailed explanation refer
 
 ## Auth token support for fetching modules
 
-Not all code openly is available on the public internet. Previously Deno had no
+Not all code is openly available on the public internet. Previously Deno had no
 capability to download code from a server that required authentication. In this
 release we have added the ability for users to specify per domain auth tokens
 that are used when fetching modules for the first time.
@@ -467,7 +467,7 @@ diagnostics the same way as the rest of the CLI.
 Two weeks ago, in Deno 1.7.5 we stabilized `deno lsp` and switched our
 [offical VS Code extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno)
 to use it. So far we have gotten some great feedback, and will be working to
-address all reported issues. If you are run into issues with the extension,
+address all reported issues. If you are running into issues with the extension,
 please report it on our issue tracker. We can not fix issues that we do not know
 about.
 


### PR DESCRIPTION
- ~~Fix languages of some code blocks~~
- Add a missing colon
- Fix some typos in the Deno 1.8 blog post