### PR TITLE
Handle URL encoded parts of non-html requests

### DIFF
--- a/worker/src/registry.ts
+++ b/worker/src/registry.ts
@@ -7,7 +7,7 @@ export const S3_BUCKET =
 
 export async function handleRegistryRequest(url: URL): Promise<Response> {
   console.log("registry request", url.pathname);
-  const entry = parsePathname(url.pathname);
+  const entry = parsePathname(decodeURIComponent(url.pathname));
   if (!entry) {
     return new Response("This module entry is invalid: " + url.pathname, {
       status: 400,


### PR DESCRIPTION
VSCode's json language server encodes `@` as `%40` when fetching `$schema` for some json file (e.g. [one generated by `denon -i`](https://github.com/denosaurs/denon/blob/890a01ad8fae6ab294c270184c36a7ae4fcbbcc3/src/templates.ts#L15)).

Despite the fact that [browser handles `%40` just fine](https://deno.land/x/denon%402.4.7/schema.json), a fetch request gets status 404:
```
await fetch("https://deno.land/x/denon%402.4.7/schema.json", { "credentials": "omit", "mode": "cors" });
```

This PR attempts to fix that problem.