### PR TITLE
fix build.settings again and use in memory cache instead of redis

### DIFF
--- a/proxy/deps.ts
+++ b/proxy/deps.ts
@@ -4,8 +4,5 @@ export type {
   Context,
   RouterContext,
 } from "https://deno.land/x/oak@v6.5.0/mod.ts";
-export {
-  Cache,
-  redisCache,
-} from "https://deno.land/x/httpcache@0.1.0/redis.ts";
+export { Cache } from "https://deno.land/x/httpcache@0.1.0/redis.ts";
 export { inMemoryCache } from "https://deno.land/x/httpcache@0.1.0/in_memory.ts";

--- a/proxy/deps.ts
+++ b/proxy/deps.ts
@@ -4,5 +4,7 @@ export type {
   Context,
   RouterContext,
 } from "https://deno.land/x/oak@v6.5.0/mod.ts";
-export { Cache } from "https://deno.land/x/httpcache@0.1.0/redis.ts";
-export { inMemoryCache } from "https://deno.land/x/httpcache@0.1.0/in_memory.ts";
+export {
+  Cache,
+  inMemoryCache,
+} from "https://deno.land/x/httpcache@0.1.0/in_memory.ts";

--- a/proxy/fly.toml
+++ b/proxy/fly.toml
@@ -7,8 +7,9 @@ kill_timeout = 5
 
 [build]
   builtin = "deno"
-  [build.args]
-    perms='"--allow-net","--allow-env"'
+
+[build.settings]
+  perms = ["--allow-net", "--allow-env"]
 
 [[services]]
   internal_port = 8080

--- a/proxy/fly.toml
+++ b/proxy/fly.toml
@@ -27,9 +27,11 @@ kill_timeout = 5
     handlers = ["tls", "http"]
     port = "443"
 
-  [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "10s"
-    port = "8080"
-    restart_limit = 5
-    timeout = "2s"
+  [[services.http_checks]]
+    interval = 10000
+    grace_period = "5s"
+    method = "get"
+    path = "/"
+    protocol = "http"
+    timeout = 5000
+      

--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -1,17 +1,10 @@
 import { app as createApp } from "./mod.ts";
-import { Application, redisCache } from "./deps.ts";
+import { Application } from "./deps.ts";
 import { State } from "./src/utils.ts";
 
 const GIT_SHA = Deno.env.get("GIT_SHA") ?? "dev";
-const REDIS_CACHE_URL = Deno.env.get("FLY_REDIS_CACHE_URL");
 
-let state: State | undefined = undefined;
-if (typeof REDIS_CACHE_URL === "string") {
-  const cache = await redisCache(REDIS_CACHE_URL, `${GIT_SHA}-`);
-  state = { cache };
-}
-
-const app = new Application<State>({ state });
+const app = new Application<State>();
 
 // Logger
 app.use(async (ctx, next) => {

--- a/proxy/src/registry.ts
+++ b/proxy/src/registry.ts
@@ -74,7 +74,7 @@ export async function getLatestVersion(
     `${S3_BUCKET}${module}/meta/versions.json`,
   );
   if (!res.ok) {
-    if (res.body) await res.body.cancel();
+    if (res.body) await res.arrayBuffer();
     return undefined;
   }
   const versions = await res.json();


### PR DESCRIPTION
The redis cache is very slow. We can use it as a secondary cache in the future, but for now just an in memory cache should do the trick.