### PR TITLE
fix: line height and adjust spacing

### DIFF
--- a/components/markdown.css
+++ b/components/markdown.css
@@ -565,5 +565,5 @@ object {
 }
 
 .markdown-posts h2 {
-  line-height: 1.5;
+  line-height: 1.3;
 }

--- a/components/markdown.css
+++ b/components/markdown.css
@@ -556,11 +556,14 @@ object {
 }
 
 .markdown-posts h1,
-.markdown-posts h2,
 .markdown-posts h3,
 .markdown-posts h4,
 .markdown-posts h5,
 .markdown-posts h6 {
   line-height: 1;
   margin-top: 40px;
+}
+
+.markdown-posts h2 {
+  line-height: 1.5;
 }

--- a/pages/posts/[post].tsx
+++ b/pages/posts/[post].tsx
@@ -100,7 +100,7 @@ function NewsPostPage(props: Props): React.ReactElement {
         <Link href="/posts">
           <a className="link">&lt;- Other News</a>
         </Link>
-        <h1 className="tracking-tight font-bold text-5xl leading-10 mt-4 py-8">
+        <h1 className="tracking-tight font-bold text-3xl leading-8 sm:text-4xl md:text-5xl mt-4 py-4 sm:py-6">
           {props.meta.title}
         </h1>
         <a
@@ -125,7 +125,7 @@ function NewsPostPage(props: Props): React.ReactElement {
           {format.format(date)}
         </p>
         <p className="text-gray-500 mt-3 leading-tight">{props.meta.author}</p>
-        <div className="mt-8 -mx-4">
+        <div className="-mx-4 sm:mt-2">
           <Markdown
             source={props.markdown}
             displayURL={`https://deno.land/posts/${props.meta.id}`}

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -40,7 +40,7 @@ function PostsIndexPage(props: Props): React.ReactElement | null {
       <div className="bg-white pt-2 pb-20 px-4 sm:px-6 lg:pt-8 lg:pb-28 lg:px-8">
         <div className="relative max-w-screen-lg mx-auto">
           <div className="border-b-2 border-gray-100 pb-8">
-            <h2 className="text-5xl font-bold tracking-tight">News</h2>
+            <h2 className="text-4xl font-bold tracking-tight">News</h2>
           </div>
           <div className="mt-6 grid gap-16 lg:grid-cols-2 lg:col-gap-5 lg:row-gap-12">
             {props.posts

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -37,10 +37,10 @@ function PostsIndexPage(props: Props): React.ReactElement | null {
         <title>News | Deno</title>
       </Head>
       <Header />
-      <div className="bg-white pt-8 pb-20 px-4 sm:px-6 lg:pt-8 lg:pb-28 lg:px-8">
+      <div className="bg-white pt-2 pb-20 px-4 sm:px-6 lg:pt-8 lg:pb-28 lg:px-8">
         <div className="relative max-w-screen-lg mx-auto">
-          <div className="border-b-2 border-gray-100 pb-10">
-            <h2 className="text-4xl font-bold tracking-tight">News</h2>
+          <div className="border-b-2 border-gray-100 pb-8">
+            <h2 className="text-5xl font-bold tracking-tight">News</h2>
           </div>
           <div className="mt-6 grid gap-16 lg:grid-cols-2 lg:col-gap-5 lg:row-gap-12">
             {props.posts


### PR DESCRIPTION
This PR fixes #1699 and changes the spacing of the titles in the news section to make better use of the already limited space on mobile devices.

For reference:

Old title for posts:
<img width="299" alt="Bildschirmfoto 2021-03-09 um 11 48 53" src="https://user-images.githubusercontent.com/35741000/110460128-13e00980-80ce-11eb-87fc-cf65423f5bc5.png">

New title for posts:
<img width="299" alt="Bildschirmfoto 2021-03-09 um 11 49 05" src="https://user-images.githubusercontent.com/35741000/110460159-1fcbcb80-80ce-11eb-9875-a781a380b4c9.png">


Old subtitle for h2 in markdown:
<img width="298" alt="Bildschirmfoto 2021-03-09 um 11 51 07" src="https://user-images.githubusercontent.com/35741000/110460234-34a85f00-80ce-11eb-8df6-a14ac65c5eea.png">

New subtitle for h2 in markdown:
<img width="299" alt="Bildschirmfoto 2021-03-09 um 11 50 57" src="https://user-images.githubusercontent.com/35741000/110460262-3d993080-80ce-11eb-80aa-77339cfd931d.png">
