### PR TITLE
fix subtitles on blog

### DIFF
--- a/components/markdown.css
+++ b/components/markdown.css
@@ -561,6 +561,5 @@ object {
 .markdown-posts h4,
 .markdown-posts h5,
 .markdown-posts h6 {
-  line-height: 1;
   margin-top: 40px;
 }


### PR DESCRIPTION
fixes the overlapping of subtitles on blog

before:
<img width="451" alt="Bildschirmfoto 2021-03-09 um 13 38 10" src="https://user-images.githubusercontent.com/35741000/110471720-bef7bf80-80dc-11eb-8e86-5e13e383c480.png">

after:
<img width="454" alt="Bildschirmfoto 2021-03-09 um 13 38 23" src="https://user-images.githubusercontent.com/35741000/110471726-c323dd00-80dc-11eb-8ef9-5981e3ecebdd.png">
