### PR TITLE
fix: broken link in benchmarks

### DIFF
--- a/pages/benchmarks.tsx
+++ b/pages/benchmarks.tsx
@@ -145,7 +145,7 @@ function Benchmarks(): React.ReactElement {
                 </li>
                 <li>
                   <SourceLink
-                    path="cli/tests/workers_round_robin_bench.ts"
+                    path="cli/tests/workers/bench_round_robin.ts"
                     name="workers_round_robin"
                   />
                 </li>


### PR DESCRIPTION
Due to https://github.com/denoland/deno/pull/9493,
Link to worker round robin test from benchmarks page has been broken.
This fixes that.