### PR TITLE
Correctly handle module version

### DIFF
--- a/components/DirectoryListing.tsx
+++ b/components/DirectoryListing.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useState, createRef, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { isReadme, DirListing } from "../util/registry_utils";
+import { isReadme, DirListing, getBasePath } from "../util/registry_utils";
 
 function DirectoryListing(props: {
   dirListing: DirListing[];
@@ -123,13 +123,11 @@ function DirectoryListing(props: {
               {display
                 .sort((a, b) => a.type.localeCompare(b.type))
                 .map((entry, i) => {
-                  const href = encodeURI(
-                    `${isStd ? "" : "/x"}/${props.name}${
-                      props.version ? `@${props.version}` : ""
-                    }${props.path}/${entry.path ? entry.path + "/" : ""}${
+                  const href =
+                    `${getBasePath({ isStd, name: props.name, version: props.version })}${props.path}/${entry.path ? entry.path + "/" : ""}${
                       entry.name
                     }`
-                  );
+                  ;
                   return (
                     <tr
                       key={i}

--- a/components/DirectoryListing.tsx
+++ b/components/DirectoryListing.tsx
@@ -123,11 +123,13 @@ function DirectoryListing(props: {
               {display
                 .sort((a, b) => a.type.localeCompare(b.type))
                 .map((entry, i) => {
-                  const href =
-                    `${getBasePath({ isStd, name: props.name, version: props.version })}${props.path}/${entry.path ? entry.path + "/" : ""}${
-                      entry.name
-                    }`
-                  ;
+                  const href = `${getBasePath({
+                    isStd,
+                    name: props.name,
+                    version: props.version,
+                  })}${props.path}/${entry.path ? entry.path + "/" : ""}${
+                    entry.name
+                  }`;
                   return (
                     <tr
                       key={i}

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -46,7 +46,7 @@ function Manual(): React.ReactElement {
   const { version, path } = useMemo(() => {
     const [identifier, ...pathParts] = (query.rest as string[]) ?? [];
     const path = pathParts.length === 0 ? "" : `/${pathParts.join("/")}`;
-    const version = parseNameVersion(identifier ?? "")[1] ?? versionMeta.cli[0];
+    const version = parseNameVersion(identifier ?? "")[1] || versionMeta.cli[0];
     return { version, path: path || "/introduction" };
   }, [query]);
 

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -91,10 +91,6 @@ function Registry(): React.ReactElement {
     version,
     path,
   ]);
-  const repositoryURL = useMemo(
-    () => (versionMeta ? getRepositoryURL(versionMeta, path) : undefined),
-    [versionMeta, path]
-  );
   const documentationURL = useMemo(() => {
     const doc = `https://doc.deno.land/https/deno.land${canonicalPath}`;
     return denoDocAvailableForURL(canonicalPath) ? doc : null;
@@ -196,6 +192,16 @@ function Registry(): React.ReactElement {
     }
     return versionMeta;
   }, [versionMeta, path]);
+
+  const repositoryURL = useMemo(
+    () =>
+      versionMeta
+        ? dirEntries
+          ? getRepositoryURL(versionMeta, path, "tree")
+          : getRepositoryURL(versionMeta, path)
+        : undefined,
+    [versionMeta, path, dirEntries]
+  );
 
   const {
     readmeCanonicalPath,

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -21,6 +21,7 @@ import {
   VersionDeps,
   getVersionDeps,
   listExternalDependencies,
+  getBasePath,
 } from "../util/registry_utils";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -54,9 +55,7 @@ function Registry(): React.ReactElement {
   }, [query]);
   function gotoVersion(newVersion: string, doReplace?: boolean) {
     const href = `${!isStd ? "/x" : ""}/[...rest]`;
-    const asPath = `${!isStd ? "/x" : ""}/${
-      name + (newVersion !== "" ? `@${newVersion}` : "")
-    }${path}`;
+    const asPath = `${getBasePath({ isStd, name, version: newVersion })}${path}`;
     if (doReplace) {
       replace(href, asPath + location.hash);
     } else {
@@ -78,7 +77,7 @@ function Registry(): React.ReactElement {
 
   // Base paths
   const basePath = useMemo(
-    () => `${isStd ? "" : "/x"}/${name}${version ? `@${version}` : ""}`,
+    () => getBasePath({ isStd, name, version }),
     [name, version]
   );
   // File paths
@@ -93,7 +92,7 @@ function Registry(): React.ReactElement {
     [versionMeta, path]
   );
   const documentationURL = useMemo(() => {
-    const doc = `https://doc.deno.land/https/deno.land/${canonicalPath}`;
+    const doc = `https://doc.deno.land/https/deno.land${canonicalPath}`;
     return denoDocAvailableForURL(canonicalPath) ? doc : null;
   }, [canonicalPath]);
 
@@ -632,7 +631,7 @@ function Breadcrumbs({
         </>
       )}
       <Link
-        href={`${!isStd ? "/x" : ""}/${name}${version ? `@${version}` : ""}`}
+        href={getBasePath({ isStd, name, version })}
       >
         <a className="link">
           {name}
@@ -648,9 +647,7 @@ function Breadcrumbs({
               {" "}
               /{" "}
               <Link
-                href={`${!isStd ? "/x" : ""}/${name}${
-                  version ? `@${version}` : ""
-                }${link ? `/${link}` : ""}`}
+                href={`${getBasePath({ isStd, name, version })}${link ? `/${link}` : ""}`}
               >
                 <a className="link">{p}</a>
               </Link>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -55,7 +55,11 @@ function Registry(): React.ReactElement {
   }, [query]);
   function gotoVersion(newVersion: string, doReplace?: boolean) {
     const href = `${!isStd ? "/x" : ""}/[...rest]`;
-    const asPath = `${getBasePath({ isStd, name, version: newVersion })}${path}`;
+    const asPath = `${getBasePath({
+      isStd,
+      name,
+      version: newVersion,
+    })}${path}`;
     if (doReplace) {
       replace(href, asPath + location.hash);
     } else {
@@ -76,10 +80,10 @@ function Registry(): React.ReactElement {
   }
 
   // Base paths
-  const basePath = useMemo(
-    () => getBasePath({ isStd, name, version }),
-    [name, version]
-  );
+  const basePath = useMemo(() => getBasePath({ isStd, name, version }), [
+    name,
+    version,
+  ]);
   // File paths
   const canonicalPath = useMemo(() => `${basePath}${path}`, [basePath, path]);
   const sourceURL = useMemo(() => getSourceURL(name, version, path), [
@@ -630,9 +634,7 @@ function Breadcrumbs({
           /{" "}
         </>
       )}
-      <Link
-        href={getBasePath({ isStd, name, version })}
-      >
+      <Link href={getBasePath({ isStd, name, version })}>
         <a className="link">
           {name}
           {version ? `@${version}` : ""}
@@ -647,7 +649,9 @@ function Breadcrumbs({
               {" "}
               /{" "}
               <Link
-                href={`${getBasePath({ isStd, name, version })}${link ? `/${link}` : ""}`}
+                href={`${getBasePath({ isStd, name, version })}${
+                  link ? `/${link}` : ""
+                }`}
               >
                 <a className="link">{p}</a>
               </Link>

--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -95,7 +95,7 @@ const versionMeta: VersionMetaInfo = {
 
 test("getRepositoryURL", () => {
   expect(getRepositoryURL(versionMeta, "/README.md")).toEqual(
-    "https://github.com/luca-rand/testing/tree/0.0.8/README.md"
+    "https://github.com/luca-rand/testing/blob/0.0.8/README.md"
   );
 });
 

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -25,13 +25,14 @@ function pathJoin(...parts: string[]) {
 
 export function getRepositoryURL(
   meta: VersionMetaInfo,
-  path: string
+  path: string,
+  type = "blob"
 ): string | undefined {
   switch (meta.uploadOptions.type) {
     case "github":
       return `https://github.com/${pathJoin(
         meta.uploadOptions.repository,
-        "tree",
+        type,
         meta.uploadOptions.ref,
         meta.uploadOptions.subdir ?? "",
         path

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -518,10 +518,16 @@ export async function getStats(): Promise<{
   return data.data;
 }
 
-export function getBasePath({ isStd, name, version }: {
-  isStd: Boolean,
-  name: string,
-  version?: string
+export function getBasePath({
+  isStd,
+  name,
+  version,
+}: {
+  isStd: Boolean;
+  name: string;
+  version?: string;
 }) {
-  return `${isStd ? "" : "/x"}/${name}${version ? `@${encodeURIComponent(version)}` : ""}`
+  return `${isStd ? "" : "/x"}/${name}${
+    version ? `@${encodeURIComponent(version)}` : ""
+  }`;
 }

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -257,8 +257,8 @@ export async function getBuild(id: string): Promise<Build> {
 }
 
 export function parseNameVersion(nameVersion: string): [string, string] {
-  const [name, version] = nameVersion.split("@", 2);
-  return [name, version];
+  const [name, ...version] = nameVersion.split("@");
+  return [name, version.join("@")];
 }
 
 export function fileTypeFromURL(filename: string): string | undefined {
@@ -516,4 +516,12 @@ export async function getStats(): Promise<{
   }
 
   return data.data;
+}
+
+export function getBasePath({ isStd, name, version }: {
+  isStd: Boolean,
+  name: string,
+  version?: string
+}) {
+  return `${isStd ? "" : "/x"}/${name}${version ? `@${encodeURIComponent(version)}` : ""}`
 }

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -523,10 +523,10 @@ export function getBasePath({
   name,
   version,
 }: {
-  isStd: Boolean;
+  isStd: boolean;
   name: string;
   version?: string;
-}) {
+}): string {
   return `${isStd ? "" : "/x"}/${name}${
     version ? `@${encodeURIComponent(version)}` : ""
   }`;


### PR DESCRIPTION
[xstate](https://github.com/davidkpiano/xstate) - this module is painful because its version has @ (at) and / (slash), which breaks literally everything:

- deno.land website
- deno.land proxy
- cdn.deno.land
- doc.deno.land

Yet this module is the 5th one on deno.land/x, which is why I spotted this issue.

- This PR fixes the website
- I will submit a PR to doc.deno.land
- I don't know how cdn.deno.land exactly works, but `getVersionDeps` fails on both escaped URL (https://cdn.deno.land/xstate/versions/xstate%404.16.2/meta/deps_v2.json) and unescaped (https://cdn.deno.land/xstate/versions/xstate@4.16.2/meta/deps_v2.json)
- Unfortunately for the proxy, I found oak decodes the URL before passing it to path-to-regexp, so the router can't match the correct version even if we escaped it. I will submit a PR to them as well.

P.S. dealing with all these paths is a nightmare, I think a helper function for creating these URL is needed or there will be more issues in the future.

Close #1718