### PR TITLE
fix: proxy/vscode ".js" files are accidentally filtered out because of typo

### DIFF
--- a/proxy/src/vscode.ts
+++ b/proxy/src/vscode.ts
@@ -90,7 +90,7 @@ async function getPaths(
     .map((f) => f.path.substring(1))
     .filter(
       (f) =>
-        f.endsWith(".jsx") ||
+        f.endsWith(".js") ||
         f.endsWith(".jsx") ||
         f.endsWith(".ts") ||
         f.endsWith(".tsx") ||


### PR DESCRIPTION
In `getPaths` function where files are filtered out by extension, there is a duplicated condition with `f.endsWith(".jsx")` instead of `f.endsWith(".js")`.