### PR TITLE
style: add border radius to .prism-code

### DIFF
--- a/components/app.css
+++ b/components/app.css
@@ -52,6 +52,7 @@ ol.nested li:before {
 }
 
 .prism-code {
+  border-radius: .25rem;
   tab-size: 2;
   -moz-tab-size: 2;
 }


### PR DESCRIPTION
I added a bit of radius to .prism-code, and IMO it looks better especially on mobile.
But I don't mind if this PR will not be accepted. I'm just suggesting. 😄 