### PR TITLE
fix: fix low contrast token in CodeBlock

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -5,6 +5,16 @@ import Highlight, { Prism } from "prism-react-renderer";
 import light from "prism-react-renderer/themes/github";
 import { useLayoutEffect } from "react";
 
+// Modifies the color of 'variable' token
+// to avoid poor contrast
+// ref: https://github.com/denoland/deno_website2/issues/1724
+for (const style of light.styles) {
+  if (style.types.includes("variable")) {
+    // Chrome suggests this color instead of rgb(156, 220, 254);
+    style.style.color = "rgb(61, 88, 101)";
+  }
+}
+
 (typeof global !== "undefined" ? global : (window as any)).Prism = Prism;
 
 require("prismjs/components/prism-rust");


### PR DESCRIPTION
This PR fixes the color of low contrast token in CodeBlock. ref: #1724 

Before
<img width="926" alt="スクリーンショット 2021-03-31 18 06 15" src="https://user-images.githubusercontent.com/613956/113119796-cd547980-924b-11eb-8661-a9ef300e974d.png">

After (`navigator`'s color is changed)
<img width="936" alt="スクリーンショット 2021-03-31 18 00 46" src="https://user-images.githubusercontent.com/613956/113119819-d6454b00-924b-11eb-96a2-a1215e70df80.png">

closes #1724