### PR TITLE
fix(manual): default to latest `std` if not on a known cli version

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -215,7 +215,7 @@ function Manual(): React.ReactElement {
   const stdVersion =
     version === undefined
       ? versionMeta.std[0]
-      : ((versionMeta.cli_to_std as any)[version ?? ""] as string) ?? version;
+      : ((versionMeta.cli_to_std as any)[version ?? ""] as string) ?? versionMeta.std[0];
 
   return (
     <div>

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -215,7 +215,8 @@ function Manual(): React.ReactElement {
   const stdVersion =
     version === undefined
       ? versionMeta.std[0]
-      : ((versionMeta.cli_to_std as any)[version ?? ""] as string) ?? versionMeta.std[0];
+      : ((versionMeta.cli_to_std as any)[version ?? ""] as string) ??
+        versionMeta.std[0];
 
   return (
     <div>


### PR DESCRIPTION
Fixes denoland/deno#10237