### PR TITLE
fix: Manual "prev"/"next" links are untagged

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -511,14 +511,32 @@ function Manual(): React.ReactElement {
                   />
                   <div className="mt-4 pt-4 border-t border-gray-200">
                     {pageList[pageIndex - 1] !== undefined && (
-                      <Link href={pageList[pageIndex - 1].path}>
+                      <Link
+                        href={
+                          version
+                            ? pageList[pageIndex - 1].path.replace(
+                                "manual",
+                                `manual@${version}`
+                              )
+                            : pageList[pageIndex - 1].path
+                        }
+                      >
                         <a className="text-gray-900 hover:text-gray-600 font-normal">
                           ← {pageList[pageIndex - 1].name}
                         </a>
                       </Link>
                     )}
                     {pageList[pageIndex + 1] !== undefined && (
-                      <Link href={pageList[pageIndex + 1].path}>
+                      <Link
+                        href={
+                          version
+                            ? pageList[pageIndex + 1].path.replace(
+                                "manual",
+                                `manual@${version}`
+                              )
+                            : pageList[pageIndex + 1].path
+                        }
+                      >
                         <a className="text-gray-900 hover:text-gray-600 font-normal float-right">
                           {pageList[pageIndex + 1].name} →
                         </a>


### PR DESCRIPTION
Resolve #1798

This PR  has been fixed so that when you were browsing  manual page with untagged version, clicking on the prev/next link will be redirected to the version you were browsing.

> The previous/next links at the bottom of a manual page link to the untagged version, meaning that if someone is browsing any but the default tag for the manual and they click a prev/next link, they will be redirected to the current version of the manual, versus the version they were browsing.
For example, navigate to: https://deno.land/manual@v1.7.5/introduction and click the "Getting Started ->" link.

