### PR TITLE
chore: update to use new manual repo

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -1,25 +1,26 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 import React, {
-  useState,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
-  useCallback,
+  useState,
 } from "react";
 import { createPortal } from "react-dom";
 import Head from "next/head";
 import Link from "next/link";
-import { useRouter, Router } from "next/router";
+import { Router, useRouter } from "next/router";
 // @ts-expect-error because @docsearch/react does not have types
 import { DocSearchModal, useDocSearchKeyboardEvents } from "@docsearch/react";
 import versionMeta from "../versions.json";
 import { parseNameVersion } from "../util/registry_utils";
 import {
-  TableOfContents,
-  getTableOfContents,
-  getFileURL,
   getDocURL,
+  getFileURL,
+  getTableOfContents,
+  isPreviewVersion,
+  TableOfContents,
   versions,
 } from "../util/manual_utils";
 import Markdown from "./Markdown";
@@ -217,6 +218,8 @@ function Manual(): React.ReactElement {
       ? versionMeta.std[0]
       : ((versionMeta.cli_to_std as any)[version ?? ""] as string) ??
         versionMeta.std[0];
+
+  const isPreview = isPreviewVersion(version);
 
   return (
     <div>
@@ -474,6 +477,12 @@ function Manual(): React.ReactElement {
               </div>
             </div>
             <CookieBanner />
+            {isPreview ? (
+              <UserContributionBanner
+                gotoVersion={gotoVersion}
+                versions={versions}
+              />
+            ) : null}
             <div className="max-w-screen-md mx-auto px-4 sm:px-6 md:px-8 pb-12 sm:pb-20">
               {content ? (
                 <>
@@ -569,6 +578,41 @@ function Manual(): React.ReactElement {
               )}
             </div>
           </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UserContributionBanner({
+  versions,
+  gotoVersion,
+}: {
+  versions: string[];
+  gotoVersion: (version: string) => void;
+}) {
+  return (
+    <div className="bg-yellow-300 sticky top-0">
+      <div className="max-w-screen-xl mx-auto py-4 px-3 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between flex-wrap">
+          <div className="w-0 flex-1 flex items-center">
+            <p className="ml-3 font-medium text-gray-900">
+              <span>
+                You are viewing documentation generated from a{"  "}
+                <b className="font-bold">user contribution</b>
+                {"  "}
+                or an upcoming or past release. The contents of this document
+                may not have been reviewed by the Deno team.{" "}
+              </span>
+
+              <span
+                className="underline cursor-pointer text-gray-900"
+                onClick={() => gotoVersion(versions[0])}
+              >
+                Click here to view the documentation for the latest release.
+              </span>
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -1,20 +1,36 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import { getTableOfContents, getFileURL } from "./manual_utils";
+import { getFileURL, getTableOfContents } from "./manual_utils";
 import "isomorphic-unfetch";
 
 /* eslint-env jest */
 
 test("get table of contents", async () => {
   expect(
-    await getTableOfContents("f184332c09c851faac50f598d29ebe4426e05464")
+    await getTableOfContents("95b75e204ab3c0966e344a52c7bc9b9011ac345f"),
   ).toBeTruthy();
 });
 
-test("get introduction file", async () => {
+test("get introduction file commit hash", async () => {
   expect(
-    getFileURL("f184332c09c851faac50f598d29ebe4426e05464", "/introduction")
+    getFileURL("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/introduction"),
   ).toEqual(
-    "https://raw.githubusercontent.com/denoland/deno/f184332c09c851faac50f598d29ebe4426e05464/docs/introduction.md"
+    "https://raw.githubusercontent.com/denoland/manual/95b75e204ab3c0966e344a52c7bc9b9011ac345f/introduction.md",
+  );
+});
+
+test("get introduction file old repo", async () => {
+  expect(
+    getFileURL("v1.12.0", "/introduction"),
+  ).toEqual(
+    "https://deno.land/x/deno@v1.12.0/docs/introduction.md",
+  );
+});
+
+test("get introduction file new repo", async () => {
+  expect(
+    getFileURL("v1.12.1", "/introduction"),
+  ).toEqual(
+    "https://deno.land/x/manual@v1.12.1/introduction.md",
   );
 });

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -7,30 +7,26 @@ import "isomorphic-unfetch";
 
 test("get table of contents", async () => {
   expect(
-    await getTableOfContents("95b75e204ab3c0966e344a52c7bc9b9011ac345f"),
+    await getTableOfContents("95b75e204ab3c0966e344a52c7bc9b9011ac345f")
   ).toBeTruthy();
 });
 
 test("get introduction file commit hash", async () => {
   expect(
-    getFileURL("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/introduction"),
+    getFileURL("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/introduction")
   ).toEqual(
-    "https://raw.githubusercontent.com/denoland/manual/95b75e204ab3c0966e344a52c7bc9b9011ac345f/introduction.md",
+    "https://raw.githubusercontent.com/denoland/manual/95b75e204ab3c0966e344a52c7bc9b9011ac345f/introduction.md"
   );
 });
 
 test("get introduction file old repo", async () => {
-  expect(
-    getFileURL("v1.12.0", "/introduction"),
-  ).toEqual(
-    "https://deno.land/x/deno@v1.12.0/docs/introduction.md",
+  expect(getFileURL("v1.12.0", "/introduction")).toEqual(
+    "https://deno.land/x/deno@v1.12.0/docs/introduction.md"
   );
 });
 
 test("get introduction file new repo", async () => {
-  expect(
-    getFileURL("v1.12.1", "/introduction"),
-  ).toEqual(
-    "https://deno.land/x/manual@v1.12.1/introduction.md",
+  expect(getFileURL("v1.12.1", "/introduction")).toEqual(
+    "https://deno.land/x/manual@v1.12.1/introduction.md"
   );
 });

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -35,7 +35,7 @@ function isOldVersion(version: string) {
 }
 
 function basepath(version: string) {
-  if (VERSIONS.cli.find((v) => v === version) === undefined) {
+  if (isPreviewVersion(version)) {
     return githubBasepath + version;
   }
   if (isOldVersion(version)) {
@@ -45,13 +45,14 @@ function basepath(version: string) {
 }
 
 export async function getTableOfContents(
-  version: string,
+  version: string
 ): Promise<TableOfContents> {
   const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
-        .text()}`,
+      `Got an error (${
+        res.status
+      }) while getting the manual table of contents:\n${await res.text()}`
     );
   }
   return await res.json();
@@ -63,4 +64,8 @@ export function getFileURL(version: string, path: string): string {
 
 export function getDocURL(version: string, path: string): string {
   return `${docpath}${version}/docs${path}.md`;
+}
+
+export function isPreviewVersion(version: string): boolean {
+  return VERSIONS.cli.find((v) => v === version) === undefined;
 }

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -26,11 +26,11 @@ function isOldVersion(version: string) {
   const matches = version.match(SEMVER_REGEX);
   if (!matches) throw new TypeError("This shouldn't have happened!");
   return (
-    matches[0] === "0" ||
-    (matches[0] === "1" && parseInt(matches[1]) < 12) ||
-    matches[0] === "1" ||
-    matches[1] === "12" ||
-    matches[2] === "0"
+    matches[1] === "0" ||
+    (matches[1] === "1" && parseInt(matches[2]) < 12) ||
+    matches[1] === "1" ||
+    matches[2] === "12" ||
+    matches[3] === "0"
   );
 }
 
@@ -45,14 +45,13 @@ function basepath(version: string) {
 }
 
 export async function getTableOfContents(
-  version: string
+  version: string,
 ): Promise<TableOfContents> {
   const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${
-        res.status
-      }) while getting the manual table of contents:\n${await res.text()}`
+      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
+        .text()}`,
     );
   }
   return await res.json();

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -28,9 +28,7 @@ function isOldVersion(version: string) {
   return (
     matches[1] === "0" ||
     (matches[1] === "1" && parseInt(matches[2]) < 12) ||
-    (matches[1] === "1" &&
-      matches[2] === "12" &&
-      matches[3] === "0")
+    (matches[1] === "1" && matches[2] === "12" && matches[3] === "0")
   );
 }
 
@@ -45,13 +43,14 @@ function basepath(version: string) {
 }
 
 export async function getTableOfContents(
-  version: string,
+  version: string
 ): Promise<TableOfContents> {
   const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
-        .text()}`,
+      `Got an error (${
+        res.status
+      }) while getting the manual table of contents:\n${await res.text()}`
     );
   }
   return await res.json();

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -1,8 +1,9 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-const xBasepath = "https://deno.land/x/deno@";
-const githubBasepath = "https://raw.githubusercontent.com/denoland/deno/";
-const docpath = "https://github.com/denoland/deno/blob/";
+const oldXBasepath = "https://deno.land/x/deno@";
+const xBasepath = "https://deno.land/x/manual@";
+const githubBasepath = "https://raw.githubusercontent.com/denoland/manual/";
+const docpath = "https://github.com/denoland/manual/blob/";
 import VERSIONS from "../versions.json";
 
 export const versions = VERSIONS.cli;
@@ -16,28 +17,44 @@ export interface TableOfContents {
   };
 }
 
+const SEMVER_REGEX = /v?(\d+)\.(\d+)\.(\d+)/;
+
+// Returns true if the version is of the 0.x release line, or betwen 1.0.0 and
+// 1.12.0 inclusive. During this time the manual was part of the main repo. It
+// is now a seperate repo.
+function isOldVersion(version: string) {
+  const matches = version.match(SEMVER_REGEX);
+  if (!matches) throw new TypeError("This shouldn't have happened!");
+  return matches[0] === "0" ||
+    (matches[0] === "1" && parseInt(matches[1]) < 12) ||
+    (matches[0] === "1" || matches[1] === "12" || matches[2] === "0");
+}
+
 function basepath(version: string) {
-  return VERSIONS.cli.find((v) => v === version) === undefined
-    ? githubBasepath
-    : xBasepath;
+  if (VERSIONS.cli.find((v) => v === version) === undefined) {
+    return githubBasepath + version;
+  }
+  if (isOldVersion(version)) {
+    return oldXBasepath + version + "/docs";
+  }
+  return xBasepath + version;
 }
 
 export async function getTableOfContents(
-  version: string
+  version: string,
 ): Promise<TableOfContents> {
-  const res = await fetch(`${basepath(version)}${version}/docs/toc.json`);
+  const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${
-        res.status
-      }) while getting the manual table of contents:\n${await res.text()}`
+      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
+        .text()}`,
     );
   }
   return await res.json();
 }
 
 export function getFileURL(version: string, path: string): string {
-  return `${basepath(version)}${version}/docs${path}.md`;
+  return `${basepath(version)}${path}.md`;
 }
 
 export function getDocURL(version: string, path: string): string {

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -25,9 +25,13 @@ const SEMVER_REGEX = /v?(\d+)\.(\d+)\.(\d+)/;
 function isOldVersion(version: string) {
   const matches = version.match(SEMVER_REGEX);
   if (!matches) throw new TypeError("This shouldn't have happened!");
-  return matches[0] === "0" ||
+  return (
+    matches[0] === "0" ||
     (matches[0] === "1" && parseInt(matches[1]) < 12) ||
-    (matches[0] === "1" || matches[1] === "12" || matches[2] === "0");
+    matches[0] === "1" ||
+    matches[1] === "12" ||
+    matches[2] === "0"
+  );
 }
 
 function basepath(version: string) {
@@ -41,13 +45,14 @@ function basepath(version: string) {
 }
 
 export async function getTableOfContents(
-  version: string,
+  version: string
 ): Promise<TableOfContents> {
   const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
-        .text()}`,
+      `Got an error (${
+        res.status
+      }) while getting the manual table of contents:\n${await res.text()}`
     );
   }
   return await res.json();

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -28,9 +28,9 @@ function isOldVersion(version: string) {
   return (
     matches[1] === "0" ||
     (matches[1] === "1" && parseInt(matches[2]) < 12) ||
-    matches[1] === "1" ||
-    matches[2] === "12" ||
-    matches[3] === "0"
+    (matches[1] === "1" &&
+      matches[2] === "12" &&
+      matches[3] === "0")
   );
 }
 
@@ -45,14 +45,13 @@ function basepath(version: string) {
 }
 
 export async function getTableOfContents(
-  version: string
+  version: string,
 ): Promise<TableOfContents> {
   const res = await fetch(`${basepath(version)}/toc.json`);
   if (res.status !== 200) {
     throw Error(
-      `Got an error (${
-        res.status
-      }) while getting the manual table of contents:\n${await res.text()}`
+      `Got an error (${res.status}) while getting the manual table of contents:\n${await res
+        .text()}`,
     );
   }
   return await res.json();


### PR DESCRIPTION
Docs before 1.12.1 come from deno.land/x/deno/docs, newer ones come from deno.land/x/manual.

Git commit hash docs come from github.com/denoland/manual. They also show an obnoxious warning now because the content might come from a fork which we want to disclose:

![image](https://user-images.githubusercontent.com/7829205/126405651-d7889e2e-c0f6-47df-a917-4e0f7fccd7c2.png)
