### PR TITLE
fix: Make title of manual pages more descriptive

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -511,14 +511,32 @@ function Manual(): React.ReactElement {
                   />
                   <div className="mt-4 pt-4 border-t border-gray-200">
                     {pageList[pageIndex - 1] !== undefined && (
-                      <Link href={pageList[pageIndex - 1].path}>
+                      <Link
+                        href={
+                          version
+                            ? pageList[pageIndex - 1].path.replace(
+                                "manual",
+                                `manual@${version}`
+                              )
+                            : pageList[pageIndex - 1].path
+                        }
+                      >
                         <a className="text-gray-900 hover:text-gray-600 font-normal">
                           ← {pageList[pageIndex - 1].name}
                         </a>
                       </Link>
                     )}
                     {pageList[pageIndex + 1] !== undefined && (
-                      <Link href={pageList[pageIndex + 1].path}>
+                      <Link
+                        href={
+                          version
+                            ? pageList[pageIndex + 1].path.replace(
+                                "manual",
+                                `manual@${version}`
+                              )
+                            : pageList[pageIndex + 1].path
+                        }
+                      >
                         <a className="text-gray-900 hover:text-gray-600 font-normal float-right">
                           {pageList[pageIndex + 1].name} →
                         </a>

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -155,7 +155,7 @@ function Manual(): React.ReactElement {
       .then((text: string) => {
         setContent(text);
         const result = text.match(/^#+ (.*)$/m);
-        setPageTitle(result ? result[1] : "Manual");
+        setPageTitle(result ? result[1] : "");
       })
       .catch((e) => {
         console.error("Failed to fetch content:", e);
@@ -229,7 +229,9 @@ function Manual(): React.ReactElement {
   return (
     <div>
       <Head>
-        <title>{`${pageTitle} | Deno`}</title>
+        <title>
+          {pageTitle === "" ? "Manual | Deno" : `${pageTitle} | Manual | Deno`}
+        </title>
         <link
           rel="preconnect"
           href="https://BH4D9OD16A-dsn.algolia.net"

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -140,6 +140,7 @@ function Manual(): React.ReactElement {
     path,
   ]);
 
+  const [pageTitle, setPageTitle] = useState<string>("");
   useEffect(() => {
     setContent(null);
     fetch(sourceURL)
@@ -151,7 +152,11 @@ function Manual(): React.ReactElement {
         }
         return res.text();
       })
-      .then(setContent)
+      .then((text: string) => {
+        setContent(text);
+        const result = text.match(/^#+ (.*)$/m);
+        setPageTitle(result ? result[1] : "Manual");
+      })
       .catch((e) => {
         console.error("Failed to fetch content:", e);
         setContent(
@@ -224,7 +229,7 @@ function Manual(): React.ReactElement {
   return (
     <div>
       <Head>
-        <title>Manual | Deno</title>
+        <title>{`${pageTitle} | Deno`}</title>
         <link
           rel="preconnect"
           href="https://BH4D9OD16A-dsn.algolia.net"

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -18,6 +18,7 @@ import { parseNameVersion } from "../util/registry_utils";
 import {
   getDocURL,
   getFileURL,
+  getPageTitle,
   getTableOfContents,
   isPreviewVersion,
   TableOfContents,
@@ -152,17 +153,14 @@ function Manual(): React.ReactElement {
         }
         return res.text();
       })
-      .then((text: string) => {
-        setContent(text);
-        const result = text.match(/^#+ (.*)$/m);
-        setPageTitle(result ? result[1] : "");
-      })
+      .then(setContent)
       .catch((e) => {
         console.error("Failed to fetch content:", e);
         setContent(
           "# 404 - Not Found\nWhoops, the page does not seem to exist."
         );
       });
+      getPageTitle(version, path).then(setPageTitle);
   }, [sourceURL]);
 
   // SEARCH

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -160,7 +160,7 @@ function Manual(): React.ReactElement {
           "# 404 - Not Found\nWhoops, the page does not seem to exist."
         );
       });
-      getPageTitle(version, path).then(setPageTitle);
+    getPageTitle(version, path).then(setPageTitle);
   }, [sourceURL]);
 
   // SEARCH

--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -18,8 +18,8 @@ import { parseNameVersion } from "../util/registry_utils";
 import {
   getDocURL,
   getFileURL,
-  getPageTitle,
   getTableOfContents,
+  getTableOfContentsMap,
   isPreviewVersion,
   TableOfContents,
   versions,
@@ -142,6 +142,10 @@ function Manual(): React.ReactElement {
   ]);
 
   const [pageTitle, setPageTitle] = useState<string>("");
+  const tableOfContentsMap = useMemo(
+    async () => await getTableOfContentsMap(version),
+    [version]
+  );
   useEffect(() => {
     setContent(null);
     fetch(sourceURL)
@@ -160,7 +164,9 @@ function Manual(): React.ReactElement {
           "# 404 - Not Found\nWhoops, the page does not seem to exist."
         );
       });
-    getPageTitle(version, path).then(setPageTitle);
+    tableOfContentsMap.then((map: Map<string, string>): void =>
+      setPageTitle(map.get(path) || "")
+    );
   }, [sourceURL]);
 
   // SEARCH

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import { getFileURL, getTableOfContents } from "./manual_utils";
+import { getFileURL, getTableOfContents, getPageTitle } from "./manual_utils";
 import "isomorphic-unfetch";
 
 /* eslint-env jest */
@@ -29,4 +29,13 @@ test("get introduction file new repo", async () => {
   expect(getFileURL("v1.12.1", "/introduction")).toEqual(
     "https://deno.land/x/manual@v1.12.1/introduction.md"
   );
+});
+
+test("get page title", async () => {
+  expect(
+    await getPageTitle("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/getting_started")
+  ).toEqual("Getting Started");
+  expect(
+    await getPageTitle("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/getting_started/installation")
+  ).toEqual("Installation");
 });

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -1,6 +1,10 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import { getFileURL, getTableOfContents, getPageTitle } from "./manual_utils";
+import {
+  getFileURL,
+  getTableOfContents,
+  getTableOfContentsMap,
+} from "./manual_utils";
 import "isomorphic-unfetch";
 
 /* eslint-env jest */
@@ -33,15 +37,16 @@ test("get introduction file new repo", async () => {
 
 test("get page title", async () => {
   expect(
-    await getPageTitle(
-      "95b75e204ab3c0966e344a52c7bc9b9011ac345f",
-      "/getting_started"
-    )
+    await getTableOfContentsMap(
+      "95b75e204ab3c0966e344a52c7bc9b9011ac345f"
+    ).then((tableOfContentsMap) => tableOfContentsMap.get("/getting_started"))
   ).toEqual("Getting Started");
+
   expect(
-    await getPageTitle(
-      "95b75e204ab3c0966e344a52c7bc9b9011ac345f",
-      "/getting_started/installation"
+    await getTableOfContentsMap(
+      "95b75e204ab3c0966e344a52c7bc9b9011ac345f"
+    ).then((tableOfContentsMap) =>
+      tableOfContentsMap.get("/getting_started/installation")
     )
   ).toEqual("Installation");
 });

--- a/util/manual_utils.test.ts
+++ b/util/manual_utils.test.ts
@@ -33,9 +33,15 @@ test("get introduction file new repo", async () => {
 
 test("get page title", async () => {
   expect(
-    await getPageTitle("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/getting_started")
+    await getPageTitle(
+      "95b75e204ab3c0966e344a52c7bc9b9011ac345f",
+      "/getting_started"
+    )
   ).toEqual("Getting Started");
   expect(
-    await getPageTitle("95b75e204ab3c0966e344a52c7bc9b9011ac345f", "/getting_started/installation")
+    await getPageTitle(
+      "95b75e204ab3c0966e344a52c7bc9b9011ac345f",
+      "/getting_started/installation"
+    )
   ).toEqual("Installation");
 });

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -56,12 +56,11 @@ export async function getTableOfContents(
   return await res.json();
 }
 
-export async function getPageTitle(
-  version: string,
-  path: string
-): Promise<string> {
-  const tableOfContents = await getTableOfContents(version);
+export async function getTableOfContentsMap(
+  version: string
+): Promise<Map<string, string>> {
   const map = new Map<string, string>();
+  const tableOfContents = await getTableOfContents(version);
 
   Object.entries(tableOfContents).forEach(([slug, entry]) => {
     if (entry.children) {
@@ -72,7 +71,7 @@ export async function getPageTitle(
     map.set(`/${slug}`, entry.name);
   });
 
-  return map.get(path) || "";
+  return map;
 }
 
 export function getFileURL(version: string, path: string): string {

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -57,16 +57,17 @@ export async function getTableOfContents(
 }
 
 export async function getPageTitle(
-  version: string, path: string
+  version: string,
+  path: string
 ): Promise<string> {
   const tableOfContents = await getTableOfContents(version);
   const map = new Map<string, string>();
 
   Object.entries(tableOfContents).forEach(([slug, entry]) => {
     if (entry.children) {
-      Object.entries(entry.children).forEach(([childSlug , name ]) => {
+      Object.entries(entry.children).forEach(([childSlug, name]) => {
         map.set(`/${slug}/${childSlug}`, name);
-      })
+      });
     }
     map.set(`/${slug}`, entry.name);
   });

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -56,6 +56,24 @@ export async function getTableOfContents(
   return await res.json();
 }
 
+export async function getPageTitle(
+  version: string, path: string
+): Promise<string> {
+  const tableOfContents = await getTableOfContents(version);
+  const map = new Map<string, string>();
+
+  Object.entries(tableOfContents).forEach(([slug, entry]) => {
+    if (entry.children) {
+      Object.entries(entry.children).forEach(([childSlug , name ]) => {
+        map.set(`/${slug}/${childSlug}`, name);
+      })
+    }
+    map.set(`/${slug}`, entry.name);
+  });
+
+  return map.get(path) || "";
+}
+
 export function getFileURL(version: string, path: string): string {
   return `${basepath(version)}${path}.md`;
 }


### PR DESCRIPTION
resolve https://github.com/denoland/deno_website2/issues/1766

In this PR, all Manual pages were labeled `Manual | Deno`, so the titles of the Manual pages were made more descriptive.

When the state of the sourceURL is changed, the title of the page is also changed.

The attached image is the browser history.
before | after
---- | ----
<img width="400" alt="before" src="https://user-images.githubusercontent.com/48427044/126481312-bf0a54a8-7cb3-4438-bccb-a0c64259d928.png"> | <img width="427" alt="after" src="https://user-images.githubusercontent.com/48427044/126483729-cc1e3831-40b7-4da2-88a2-80a8e0d3a742.png">





