### PR TITLE
feat: show Deploy in the header with 1% probability

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,24 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import Transition from "./Transition";
+
+/**
+ * Indicates if the "Deploy" link in the header
+ * should be displayed to the user.
+ */
+function displayDeploy() {
+  const showDeploy = localStorage.getItem("showDeploy");
+  if (showDeploy !== null) {
+    return showDeploy === "true";
+  } else {
+    // 1% probability
+    const showDeploy = Math.random() < 1 / 100;
+    localStorage.setItem("showDeploy", String(showDeploy));
+    return showDeploy;
+  }
+}
 
 function Header({
   subtitle,
@@ -12,6 +28,8 @@ function Header({
   widerContent?: boolean;
 }): React.ReactElement {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [showDeploy, setShowDeploy] = useState(false);
+  useEffect(() => setShowDeploy(displayDeploy()), []);
 
   return (
     <div className="relative py-6 z-10">
@@ -58,9 +76,13 @@ function Header({
           </button>
         </div>
         <div className="hidden lg:flex md:ml-10 items-end">
-          <Link href="/#installation">
-            <a className="font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out">
-              Install
+          <Link href="https://deno.com/deploy">
+            <a
+              className={`font-medium text-gray-500 hover:text-gray-900 transition duration-150 ease-in-out ${
+                showDeploy ? "" : "hidden"
+              }`}
+            >
+              Deploy
             </a>
           </Link>
           <Link href="/manual">
@@ -167,9 +189,13 @@ function Header({
                 </div>
               </div>
               <div className="px-2 pt-4 pb-3">
-                <Link href="/#installation">
-                  <a className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">
-                    Install
+                <Link href="https://deno.com/deploy">
+                  <a
+                    className={`block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out ${
+                      showDeploy ? "" : "hidden"
+                    }`}
+                  >
+                    Deploy
                   </a>
                 </Link>
                 <Link href="/manual">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,7 +53,7 @@ for await (const conn of listener) {
             </h2>
             <a
               href="/#installation"
-              className="rounded-full mt-4 px-8 py-2 transition-colors duration-75 ease-in-out bg-blue-500 hover:bg-blue-400 text-white shadow-lg"
+              className="rounded-full mt-8 px-8 py-2 transition-colors duration-75 ease-in-out bg-blue-500 hover:bg-blue-400 text-white text-lg shadow-lg"
             >
               Install
             </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,8 +52,14 @@ for await (const conn of listener) {
               <strong className="font-semibold">TypeScript</strong>.
             </h2>
             <a
-              href="https://github.com/denoland/deno/releases/latest"
+              href="/#installation"
               className="rounded-full mt-4 px-8 py-2 transition-colors duration-75 ease-in-out bg-blue-500 hover:bg-blue-400 text-white shadow-lg"
+            >
+              Install
+            </a>
+            <a
+              href="https://github.com/denoland/deno/releases/latest"
+              className="mt-4"
             >
               {versions.cli[0]}
             </a>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "preserve"
   },
   "exclude": ["node_modules", "worker", "public"],
   "include": [


### PR DESCRIPTION
This PR also re-positions the install link as the main call to action and moves the version link to the bottom of the install button.

With "Deploy" in the header:
<img width="1062" alt="CleanShot 2021-08-18 at 11 33 06@2x" src="https://user-images.githubusercontent.com/29819102/129846023-5d49cfad-a935-49b0-bef9-4948bcc4b4ce.png">


Without "Deploy" in the header:
<img width="1066" alt="CleanShot 2021-08-18 at 11 27 41@2x" src="https://user-images.githubusercontent.com/29819102/129845915-33c50a13-d265-4097-ba92-7d6b2ed668aa.png">

---

The failing test of the PR is unrelated to the changes.