### PR TITLE
chore: fix failing tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,13 @@ module.exports = {
     "**/__tests__/**/*.+(ts|tsx|js)",
     "**/?(*.)+(spec|test).+(ts|tsx|js)",
   ],
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        jsx: "react",
+      },
+    },
+  },
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "preserve"
   },
   "exclude": ["node_modules", "worker", "public"],
   "include": [


### PR DESCRIPTION
Next.js wants `jsx` in `tsconfig` to be set to
`preserve` and Jest doesn't like it.

This PR makes them happy and place nice with
each other.

Closes #1831 