### PR TITLE
Register .mjs as a JavaScript extension

### DIFF
--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -124,6 +124,7 @@ test("fileTypeFromURL", () => {
   const tests: Array<[string, string | undefined]> = [
     ["main.ts", "typescript"],
     ["lib.js", "javascript"],
+    ["lib.mjs", "javascript"],
     ["Component.tsx", "tsx"],
     ["Component.jsx", "jsx"],
     ["data.json", "json"],

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -278,7 +278,7 @@ export function fileTypeFromURL(filename: string): string | undefined {
   const f = filename.toLowerCase();
   if (f.endsWith(".ts")) {
     return "typescript";
-  } else if (f.endsWith(".js")) {
+  } else if (f.endsWith(".js") || f.endsWith(".mjs")) {
     return "javascript";
   } else if (f.endsWith(".tsx")) {
     return "tsx";


### PR DESCRIPTION
`.mjs` is already widely used as an extension for JavaScript.
I want to register `.mjs` for syntax highlighting.