### PR TITLE
Fixed link to std repository

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -174,10 +174,9 @@ for await (const conn of listener) {
           <p className="my-4 text-gray-700">
             Next to the Deno runtime, Deno also provides a list of audited
             standard modules that are reviewed by the Deno maintainers and are
-            guaranteed to work with a specific Deno version. These live
-            alongside the Deno source code in the{" "}
-            <a href="https://github.com/denoland/deno" className="link">
-              denoland/deno
+            guaranteed to work with a specific Deno version. These live in the{" "}
+            <a href="https://github.com/denoland/deno_std" className="link">
+              denoland/deno_std
             </a>{" "}
             repository.
           </p>


### PR DESCRIPTION
I think the standard library repository has moved to deno_std. This pr fixes that link.